### PR TITLE
Fastqc stats

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -38,12 +38,15 @@ rule all:
     "transcriptome_annotated.fasta",
     "transcriptome_annotated.pep",
     "transcriptome_TPM_blast.csv",
-    "fastqc",
-    "multiqc",
-    "edgeR_trans",
+    "fastqc_before_trim",
+    "multiqc_before_trim",
+    "fastqc_after_trim",
+    "multiqc_after_trim",
+    "multiqc_before_trim.txt",
+    "multiqc_after_trim.txt",
     "WARNING_fastqc_before_trim_overview.txt",
-    "FastQC_comparison_after_trim.txt"
-
+    "FastQC_comparison_after_trim.txt",
+    "edgeR_trans"
 
 rule clean:
   """
@@ -91,7 +94,8 @@ rule multiqc_before_trim:
   input:
     "fastqc_before_trim"
   output:
-    directory("multiqc_before_trim")
+    out_dir=directory("multiqc_before_trim"),
+    report="multiqc_before_trim.txt"
   log:
     "logs/multiqc_before_trim.log"
   params:
@@ -100,8 +104,9 @@ rule multiqc_before_trim:
     1
   shell:
     """
-    mkdir {output} &> {log}
-    multiqc -o {output} {input} &>> {log}
+    mkdir {output.out_dir} &> {log}
+    multiqc -o {output.out_dir} {input} &>> {log}
+    cp multiqc_before_trim/multiqc_data/multiqc_fastqc.txt {output.report} &>> {log}
     """
 
 rule fastqc_before_trim_warnings:
@@ -109,7 +114,7 @@ rule fastqc_before_trim_warnings:
   Prints warnings for FastQC modules which produced some warnings or fails of the input data.
   """
   input:
-    fastqc_report="multiqc_before_trim/multiqc_data/multiqc_fastqc.txt"
+    fastqc_report="multiqc_before_trim.txt"
   output:
     warning_file="WARNING_fastqc_before_trim_overview.txt"
   log:
@@ -131,7 +136,16 @@ rule fastqc_before_trim_warnings:
       adapter_content_list = []
 
       for line in fastqc_data:
-        basic_statistics, per_base_sequence_quality, per_tile_sequence_quality, per_sequence_quality_scores, per_base_sequence_content, per_sequence_gc_content, per_base_n_content, sequence_length_distribution, sequence_duplication_levels, overrepresented_sequences, adapter_content = line.split("\t")[10:]
+        print(line)
+        print(line.split("\t")[10:])
+
+        # per-tile module not present in report
+        if len(line.split("\t")[10:]) == 10:
+          basic_statistics, per_base_sequence_quality, per_sequence_quality_scores, per_base_sequence_content, per_sequence_gc_content, per_base_n_content, sequence_length_distribution, sequence_duplication_levels, overrepresented_sequences, adapter_content = line.split("\t")[10:]
+          per_tile_sequence_quality = ""
+        # per-tile module present in report
+        else:
+          basic_statistics, per_base_sequence_quality, per_tile_sequence_quality, per_sequence_quality_scores, per_base_sequence_content, per_sequence_gc_content, per_base_n_content, sequence_length_distribution, sequence_duplication_levels, overrepresented_sequences, adapter_content = line.split("\t")[10:]
         basic_statistics_list.append(basic_statistics)
         per_base_sequence_quality_list.append(per_base_sequence_quality)
         per_tile_sequence_quality_list.append(per_tile_sequence_quality)
@@ -145,172 +159,180 @@ rule fastqc_before_trim_warnings:
         adapter_content_list.append(adapter_content)
     
 
-      out_file.write("FASTQC MODULES WHICH PRODUCED SOME WARNINGS OR FAILS\n\n")
-      out_file.write("!!!Please check MultiQC output for interpretation of your data!!!\n")
-      out_file.write('-'*100)
-      out_file.write('\n')
+      out_file.writelines(f"""FASTQC MODULES WHICH PRODUCED SOME WARNINGS OR FAILS
+
+"!!!Please check MultiQC output for interpretation of your data!!!
+{'-'*100}
+""")
       # BASIC STATISTICS never produce warnings or fails
 
       # PER BASE SEQUENCE QUALITY
       if "warn" in per_base_sequence_quality_list or "fail" in per_base_sequence_quality_list:
 
-        out_file.write("**PER BASE SEQUENCE QUALITY**\n")
-        out_file.write(f"WARNING: {str(per_base_sequence_quality_list.count('warn'))} out of {str(len(per_base_sequence_quality_list))} produced WARN ({str(per_base_sequence_quality_list.count('warn')/len(per_base_sequence_quality_list)*100)}%)\n")
-        out_file.write(f"FAILURE: {str(per_base_sequence_quality_list.count('fail'))} out of {str(len(per_base_sequence_quality_list))} produced FAIL ({str(per_base_sequence_quality_list.count('fail')/len(per_base_sequence_quality_list)*100)}%)\n")
+        out_file.writelines(f"""**PER BASE SEQUENCE QUALITY**
+WARNING: {str(per_base_sequence_quality_list.count('warn'))} out of {str(len(per_base_sequence_quality_list))} produced WARN ({str(per_base_sequence_quality_list.count('warn')/len(per_base_sequence_quality_list)*100)}%)
+FAILURE: {str(per_base_sequence_quality_list.count('fail'))} out of {str(len(per_base_sequence_quality_list))} produced FAIL ({str(per_base_sequence_quality_list.count('fail')/len(per_base_sequence_quality_list)*100)}%)
 
-        out_file.write("\n")
-        out_file.write('A warning is issued if the lower quartile for any base is less than 10, or if the median for any base is less than 25.\n')
-        out_file.write('This module will raise a failure if the lower quartile for any base is less than 5 or if the median for any base is less than 20.\n')
-        out_file.write("\n")
-        out_file.write('Common reasons for warnings:\n')
-        out_file.write('The most common reason for warnings and failures in this module is a general degradation of quality over the duration of long runs. In general sequencing chemistry degrades with increasing read length and for long runs you may find that the general quality of the run falls to a level where a warning or error is triggered.\n\n')
-        out_file.write('If the quality of the library falls to a low level then the most common remedy is to perform quality trimming where reads are truncated based on their average quality. For most libraries where this type of degradation has occurred you will often be simultaneously running into the issue of adapter read-through so a combined adapter and quality trimming step is often employed.\n\n')
-        out_file.write('Another possibility is that a warn / error is triggered because of a short loss of quality earlier in the run, which then recovers to produce later good quality sequence. This can happen if there is a transient problem with the run (bubbles passing through a flowcell for example). You can normally see this type of error by looking at the per-tile quality plot (if available for your platform). In these cases trimming is not advisable as it will remove later good sequence, but you might want to consider masking bases during subsequent mapping or assembly.\n\n')
-        out_file.write('If your library has reads of varying length then you can find a warning or error is triggered from this module because of very low coverage for a given base range. Before committing to any action, check how many sequences were responsible for triggering an error by looking at the sequence length distribution module results.\n')
-        out_file.write('-'*100)
-        out_file.write('\n')
+A warning is issued if the lower quartile for any base is less than 10, or if the median for any base is less than 25.
+This module will raise a failure if the lower quartile for any base is less than 5 or if the median for any base is less than 20.
+
+Common reasons for warnings:
+The most common reason for warnings and failures in this module is a general degradation of quality over the duration of long runs. In general sequencing chemistry degrades with increasing read length and for long runs you may find that the general quality of the run falls to a level where a warning or error is triggered.
+
+If the quality of the library falls to a low level then the most common remedy is to perform quality trimming where reads are truncated based on their average quality. For most libraries where this type of degradation has occurred you will often be simultaneously running into the issue of adapter read-through so a combined adapter and quality trimming step is often employed.
+
+Another possibility is that a warn / error is triggered because of a short loss of quality earlier in the run, which then recovers to produce later good quality sequence. This can happen if there is a transient problem with the run (bubbles passing through a flowcell for example). You can normally see this type of error by looking at the per-tile quality plot (if available for your platform). In these cases trimming is not advisable as it will remove later good sequence, but you might want to consider masking bases during subsequent mapping or assembly.
+
+If your library has reads of varying length then you can find a warning or error is triggered from this module because of very low coverage for a given base range. Before committing to any action, check how many sequences were responsible for triggering an error by looking at the sequence length distribution module results.
+{'-'*100}
+""")
 
       # PER TILE SEQUENCE QUALITY
       if "warn" in per_tile_sequence_quality_list or "fail" in per_tile_sequence_quality_list:
 
-        out_file.write("**PER TILE SEQUENCE QUALITY**\n")
-        out_file.write(f"WARNING: {str(per_tile_sequence_quality_list.count('warn'))} out of {str(len(per_tile_sequence_quality_list))} produced WARN ({str(per_tile_sequence_quality_list.count('warn')/len(per_tile_sequence_quality_list)*100)}%)\n")
-        out_file.write(f"FAILURE: {str(per_tile_sequence_quality_list.count('fail'))} out of {str(len(per_tile_sequence_quality_list))} produced FAIL ({str(per_tile_sequence_quality_list.count('fail')/len(per_tile_sequence_quality_list)*100)}%)\n")
-        out_file.write('\n')
-        out_file.write('This module issues a warning if any tile shows a mean Phred score more than 2 less than the mean for that base across all tiles.\n')
-        out_file.write('This module will issue a warning if any tile shows a mean Phred score more than 5 less than the mean for that base across all tiles.\n')
-        out_file.write('\n')
-        out_file.write('Common reasons for warnings:\n')
-        out_file.write('Whilst warnings in this module can be triggered by individual specific events we have also observed that greater variation in the phred scores attributed to tiles can also appear when a flowcell is generally overloaded. In this case events appear all over the flowcell rather than being confined to a specific area or range of cycles. We would generally ignore errors which mildly affected a small number of tiles for only 1 or 2 cycles, but would pursue larger effects which showed high deviation in scores, or which persisted for several cycles.\n')
-        out_file.write('-'*100)
-        out_file.write('\n')
+        out_file.writelines(f"""**PER TILE SEQUENCE QUALITY**
+WARNING: {str(per_tile_sequence_quality_list.count('warn'))} out of {str(len(per_tile_sequence_quality_list))} produced WARN ({str(per_tile_sequence_quality_list.count('warn')/len(per_tile_sequence_quality_list)*100)}%)
+FAILURE: {str(per_tile_sequence_quality_list.count('fail'))} out of {str(len(per_tile_sequence_quality_list))} produced FAIL ({str(per_tile_sequence_quality_list.count('fail')/len(per_tile_sequence_quality_list)*100)}%)
+
+This module issues a warning if any tile shows a mean Phred score more than 2 less than the mean for that base across all tiles.
+This module will issue a warning if any tile shows a mean Phred score more than 5 less than the mean for that base across all tiles.
+
+Common reasons for warnings:
+Whilst warnings in this module can be triggered by individual specific events we have also observed that greater variation in the phred scores attributed to tiles can also appear when a flowcell is generally overloaded. In this case events appear all over the flowcell rather than being confined to a specific area or range of cycles. We would generally ignore errors which mildly affected a small number of tiles for only 1 or 2 cycles, but would pursue larger effects which showed high deviation in scores, or which persisted for several cycles.
+{'-'*100}
+""")
 
       # PER SEQUENCE QUALITY SCORES
       if "warn" in per_sequence_quality_scores_list or "fail" in per_sequence_quality_scores_list:
 
-        out_file.write("**PER SEQUENCE QUALITY SCORES**\n")
-        out_file.write(f"WARNING: {str(per_sequence_quality_scores_list.count('warn'))} out of {str(len(per_sequence_quality_scores_list))} produced WARN ({str(per_sequence_quality_scores_list.count('warn')/len(per_sequence_quality_scores_list)*100)}%)\n")
-        out_file.write(f"FAILURE: {str(per_sequence_quality_scores_list.count('fail'))} out of {str(len(per_sequence_quality_scores_list))} produced FAIL ({str(per_sequence_quality_scores_list.count('fail')/len(per_sequence_quality_scores_list)*100)}%)\n")
-        out_file.write('\n')
-        out_file.write("A warning is raised if the most frequently observed mean quality is below 27 - this equates to a 0.2% error rate.\n")
-        out_file.write('An error is raised if the most frequently observed mean quality is below 20 - this equates to a 1% error rate.\n')
-        out_file.write('\n')
-        out_file.write('Common reasons for warnings:\n')
-        out_file.write('This module is generally fairly robust and errors here usually indicate a general loss of quality within a run. For long runs this may be alleviated through quality trimming. If a bi-modal, or complex distribution is seen then the results should be evaluated in concert with the per-tile qualities (if available) since this might indicate the reason for the loss in quality of a subset of sequences.\n')
-        out_file.write('-'*100)
-        out_file.write('\n')
+        out_file.writelines(f"""**PER SEQUENCE QUALITY SCORES**
+WARNING: {str(per_sequence_quality_scores_list.count('warn'))} out of {str(len(per_sequence_quality_scores_list))} produced WARN ({str(per_sequence_quality_scores_list.count('warn')/len(per_sequence_quality_scores_list)*100)}%)
+FAILURE: {str(per_sequence_quality_scores_list.count('fail'))} out of {str(len(per_sequence_quality_scores_list))} produced FAIL ({str(per_sequence_quality_scores_list.count('fail')/len(per_sequence_quality_scores_list)*100)}%)
+
+A warning is raised if the most frequently observed mean quality is below 27 - this equates to a 0.2% error rate.
+An error is raised if the most frequently observed mean quality is below 20 - this equates to a 1% error rate.
+
+Common reasons for warnings:
+This module is generally fairly robust and errors here usually indicate a general loss of quality within a run. For long runs this may be alleviated through quality trimming. If a bi-modal, or complex distribution is seen then the results should be evaluated in concert with the per-tile qualities (if available) since this might indicate the reason for the loss in quality of a subset of sequences.
+{'-'*100}
+""")
 
       # PER BASE SEQUENCE CONTENT
       if "warn" in per_base_sequence_content_list or "fail" in per_base_sequence_content_list:
 
-        out_file.write("**PER BASE SEQUENCE CONTENT**\n")
-        out_file.write(f"WARNING: {str(per_base_sequence_content_list.count('warn'))} out of {str(len(per_base_sequence_content_list))} produced WARN ({str(per_base_sequence_content_list.count('warn')/len(per_base_sequence_content_list)*100)}%)\n")
-        out_file.write(f"FAILURE: {str(per_base_sequence_content_list.count('fail'))} out of {str(len(per_base_sequence_content_list))} produced FAIL ({str(per_base_sequence_content_list.count('fail')/len(per_base_sequence_content_list)*100)}%)\n")
-        out_file.write('\n')
-        out_file.write('A warning will be issued if the lower quartile for any base is less than 10, or if the median for any base is less than 25.\n')
-        out_file.write('This module will raise a failure if the lower quartile for any base is less than 5 or if the median for any base is less than 20.\n')
-        out_file.write('\n')
-        out_file.write('Common reasons for warnings:\n')
-        out_file.write('The most common reason for warnings and failures in this module is a general degradation of quality over the duration of long runs. In general sequencing chemistry degrades with increasing read length and for long runs you may find that the general quality of the run falls to a level where a warning or error is triggered.\n\n')
-        out_file.write('If the quality of the library falls to a low level then the most common remedy is to perform quality trimming where reads are truncated based on their average quality. For most libraries where this type of degradation has occurred you will often be simultaneously running into the issue of adapter read-through so a combined adapter and quality trimming step is often employed.\n\n')
-        out_file.write('Another possibility is that a warn / error is triggered because of a short loss of quality earlier in the run, which then recovers to produce later good quality sequence. This can happen if there is a transient problem with the run (bubbles passing through a flowcell for example). You can normally see this type of error by looking at the per-tile quality plot (if available for your platform). In these cases trimming is not advisable as it will remove later good sequence, but you might want to consider masking bases during subsequent mapping or assembly.\n\n')
-        out_file.write('If your library has reads of varying length then you can find a warning or error is triggered from this module because of very low coverage for a given base range. Before committing to any action, check how many sequences were responsible for triggering an error by looking at the sequence length distribution module results.\n')
-        out_file.write('-'*100)
-        out_file.write('\n')
+        out_file.writelines(f"""**PER BASE SEQUENCE CONTENT**
+WARNING: {str(per_base_sequence_content_list.count('warn'))} out of {str(len(per_base_sequence_content_list))} produced WARN ({str(per_base_sequence_content_list.count('warn')/len(per_base_sequence_content_list)*100)}%)
+FAILURE: {str(per_base_sequence_content_list.count('fail'))} out of {str(len(per_base_sequence_content_list))} produced FAIL ({str(per_base_sequence_content_list.count('fail')/len(per_base_sequence_content_list)*100)}%)
+
+Common reasons for warnings:
+The most common reason for warnings and failures in this module is a general degradation of quality over the duration of long runs. In general sequencing chemistry degrades with increasing read length and for long runs you may find that the general quality of the run falls to a level where a warning or error is triggered.
+
+If the quality of the library falls to a low level then the most common remedy is to perform quality trimming where reads are truncated based on their average quality. For most libraries where this type of degradation has occurred you will often be simultaneously running into the issue of adapter read-through so a combined adapter and quality trimming step is often employed.
+
+Another possibility is that a warn / error is triggered because of a short loss of quality earlier in the run, which then recovers to produce later good quality sequence. This can happen if there is a transient problem with the run (bubbles passing through a flowcell for example). You can normally see this type of error by looking at the per-tile quality plot (if available for your platform). In these cases trimming is not advisable as it will remove later good sequence, but you might want to consider masking bases during subsequent mapping or assembly.
+
+If your library has reads of varying length then you can find a warning or error is triggered from this module because of very low coverage for a given base range. Before committing to any action, check how many sequences were responsible for triggering an error by looking at the sequence length distribution module results.
+{'-'*100}
+""")
+      
 
       # PER SEQUENCE GC CONTENT
       if "warn" in per_sequence_gc_content_list or "fail" in per_sequence_gc_content_list:
 
-        out_file.write("**PER SEQUENCE GC CONTENT**\n")
-        out_file.write(f"WARNING: {str(per_sequence_gc_content_list.count('warn'))} out of {str(len(per_sequence_gc_content_list))} produced WARN ({str(per_sequence_gc_content_list.count('warn')/len(per_sequence_gc_content_list)*100)}%)\n")
-        out_file.write(f"FAILURE: {str(per_sequence_gc_content_list.count('fail'))} out of {str(len(per_sequence_gc_content_list))} produced FAIL ({str(per_sequence_gc_content_list.count('fail')/len(per_sequence_gc_content_list)*100)}%)\n")
-        out_file.write('\n')
-        out_file.write('A warning is raised if the sum of the deviations from the normal distribution represents more than 15% of the reads.\n')
-        out_file.write('This module will indicate a failure if the sum of the deviations from the normal distribution represents more than 30% of the reads.\n')
-        out_file.write('\n')
-        out_file.write('Common reasons for warnings:\n')
-        out_file.write('Warnings in this module usually indicate a problem with the library. Sharp peaks on an otherwise smooth distribution are normally the result of a specific contaminant (adapter dimers for example), which may well be picked up by the overrepresented sequences module. Broader peaks may represent contamination with a different species.\n')
-        out_file.write('-'*100)
-        out_file.write('\n')
+        out_file.writelines(f"""**PER SEQUENCE GC CONTENT**
+WARNING: {str(per_sequence_gc_content_list.count('warn'))} out of {str(len(per_sequence_gc_content_list))} produced WARN ({str(per_sequence_gc_content_list.count('warn')/len(per_sequence_gc_content_list)*100)}%)
+FAILURE: {str(per_sequence_gc_content_list.count('fail'))} out of {str(len(per_sequence_gc_content_list))} produced FAIL ({str(per_sequence_gc_content_list.count('fail')/len(per_sequence_gc_content_list)*100)}%)
+
+A warning is raised if the sum of the deviations from the normal distribution represents more than 15% of the reads.
+This module will indicate a failure if the sum of the deviations from the normal distribution represents more than 30% of the reads.
+
+Common reasons for warnings:
+Warnings in this module usually indicate a problem with the library. Sharp peaks on an otherwise smooth distribution are normally the result of a specific contaminant (adapter dimers for example), which may well be picked up by the overrepresented sequences module. Broader peaks may represent contamination with a different species.
+{'-'*100}
+""")
 
       # PER BASE N CONTENT
       if "warn" in per_base_n_content_list or "fail" in per_base_n_content_list:
 
-        out_file.write("**PER BASE N CONTENT**\n")
-        out_file.write(f"WARNING: {str(per_base_n_content_list.count('warn'))} out of {str(len(per_base_n_content_list))} produced WARN ({str(per_base_n_content_list.count('warn')/len(per_base_n_content_list)*100)}%)\n")
-        out_file.write(f"FAILURE: {str(per_base_n_content_list.count('fail'))} out of {str(len(per_base_n_content_list))} produced FAIL ({str(per_base_n_content_list.count('fail')/len(per_base_n_content_list)*100)}%)\n")
-        out_file.write('\n')
-        out_file.write('This module raises a warning if any position shows an N content of >5%.\n')
-        out_file.write('This module will raise an error if any position shows an N content of >20%.\n')
-        out_file.write('\n')
-        out_file.write('Common reasons for warnings:\n')
-        out_file.write('The most common reason for the inclusion of significant proportions of Ns is a general loss of quality, so the results of this module should be evaluated in concert with those of the various quality modules. You should check the coverage of a specific bin, since it is possible that the last bin in this analysis could contain very few sequences, and an error could be prematurely triggered in this case.\n\n')
-        out_file.write('Another common scenario is the incidence of a high proportions of N at a small number of positions early in the library, against a background of generally good quality. Such deviations can occur when you have very biased sequence composition in the library to the point that base callers can become confused and make poor calls. This type of problem will be apparent when looking at the per-base sequence content results.\n')
-        out_file.write('-'*100)
-        out_file.write('\n')
+        out_file.writelines(f"""**PER BASE N CONTENT**
+WARNING: {str(per_base_n_content_list.count('warn'))} out of {str(len(per_base_n_content_list))} produced WARN ({str(per_base_n_content_list.count('warn')/len(per_base_n_content_list)*100)}%)
+FAILURE: {str(per_base_n_content_list.count('fail'))} out of {str(len(per_base_n_content_list))} produced FAIL ({str(per_base_n_content_list.count('fail')/len(per_base_n_content_list)*100)}%)
+
+This module raises a warning if any position shows an N content of >5%.
+This module will raise an error if any position shows an N content of >20%.
+
+Common reasons for warnings:
+The most common reason for the inclusion of significant proportions of Ns is a general loss of quality, so the results of this module should be evaluated in concert with those of the various quality modules. You should check the coverage of a specific bin, since it is possible that the last bin in this analysis could contain very few sequences, and an error could be prematurely triggered in this case.
+
+Another common scenario is the incidence of a high proportions of N at a small number of positions early in the library, against a background of generally good quality. Such deviations can occur when you have very biased sequence composition in the library to the point that base callers can become confused and make poor calls. This type of problem will be apparent when looking at the per-base sequence content results.
+{'-'*100}
+""")
 
       # SEQUENCE LENGTH DISTRIBUTION
       if "warn" in sequence_length_distribution_list or "fail" in sequence_length_distribution_list:
 
-        out_file.write("**SEQUENCE LENGTH DISTRIBUTION**\n")
-        out_file.write(f"WARNING: {str(sequence_length_distribution_list.count('warn'))} out of {str(len(sequence_length_distribution_list))} produced WARN ({str(sequence_length_distribution_list.count('warn')/len(sequence_length_distribution_list)*100)}%)\n")
-        out_file.write(f"FAILURE: {str(sequence_length_distribution_list.count('fail'))} out of {str(len(sequence_length_distribution_list))} produced FAIL ({str(sequence_length_distribution_list.count('fail')/len(sequence_length_distribution_list)*100)}%)\n")
-        out_file.write('\n')
-        out_file.write('This module will raise a warning if all sequences are not the same length.\n')
-        out_file.write('This module will raise an error if any of the sequences have zero length.\n')
-        out_file.write('\n')
-        out_file.write('Common reasons for warnings:\n')
-        out_file.write('For some sequencing platforms it is entirely normal to have different read lengths so warnings here can be ignored.\n')
-        out_file.write('-'*100)
-        out_file.write('\n')
+        out_file.writelines(f"""**SEQUENCE LENGTH DISTRIBUTION**
+WARNING: {str(sequence_length_distribution_list.count('warn'))} out of {str(len(sequence_length_distribution_list))} produced WARN ({str(sequence_length_distribution_list.count('warn')/len(sequence_length_distribution_list)*100)}%)
+FAILURE: {str(sequence_length_distribution_list.count('fail'))} out of {str(len(sequence_length_distribution_list))} produced FAIL ({str(sequence_length_distribution_list.count('fail')/len(sequence_length_distribution_list)*100)}%)
+
+This module will raise a warning if all sequences are not the same length.
+This module will raise an error if any of the sequences have zero length.
+
+Common reasons for warnings:
+For some sequencing platforms it is entirely normal to have different read lengths so warnings here can be ignored.
+{'-'*100}
+""")
 
       # SEQUENCE DUPLICATION LEVELS
       if "warn" in sequence_duplication_levels_list or "fail" in sequence_duplication_levels_list:
 
-        out_file.write("**SEQUENCE DUPLICATION LEVELS**\n")
-        out_file.write(f"WARNING: {str(sequence_duplication_levels_list.count('warn'))} out of {str(len(sequence_duplication_levels_list))} produced WARN ({str(sequence_duplication_levels_list.count('warn')/len(sequence_duplication_levels_list)*100)}%)\n")
-        out_file.write(f"FAILURE: {str(sequence_duplication_levels_list.count('fail'))} out of {str(len(sequence_duplication_levels_list))} produced FAIL ({str(sequence_duplication_levels_list.count('fail')/len(sequence_duplication_levels_list)*100)}%)\n")
-        out_file.write('\n')
-        out_file.write('This module will issue a warning if non-unique sequences make up more than 20% of the total.\n')
-        out_file.write('This module will issue a error if non-unique sequences make up more than 50% of the total.\n')
-        out_file.write('\n')
-        out_file.write('Common reasons for warnings:\n')
-        out_file.write('The underlying assumption of this module is of a diverse unenriched library. Any deviation from this assumption will naturally generate duplicates and can lead to warnings or errors from this module.\n\n')
-        out_file.write('In general there are two potential types of duplicate in a library, technical duplicates arising from PCR artefacts, or biological duplicates which are natural collisions where different copies of exactly the same sequence are randomly selected. From a sequence level there is no way to distinguish between these two types and both will be reported as duplicates here.\n\n')
-        out_file.write('A warning or error in this module is simply a statement that you have exhausted the diversity in at least part of your library and are re-sequencing the same sequences. In a supposedly diverse library this would suggest that the diversity has been partially or completely exhausted and that you are therefore wasting sequencing capacity. However in some library types you will naturally tend to over-sequence parts of the library and therefore generate duplication and will therefore expect to see warnings or error from this module.\n\n')
-        out_file.write('In RNA-Seq libraries sequences from different transcripts will be present at wildly different levels in the starting population. In order to be able to observe lowly expressed transcripts it is therefore common to greatly over-sequence high expressed transcripts, and this will potentially create large set of duplicates. This will result in high overall duplication in this test, and will often produce peaks in the higher duplication bins. This duplication will come from physically connected regions, and an examination of the distribution of duplicates in a specific genomic region will allow the distinction between over-sequencing and general technical duplication, but these distinctions are not possible from raw fastq files. A similar situation can arise in highly enriched ChIP-Seq libraries although the duplication there is less pronounced. Finally, if you have a library where the sequence start points are constrained (a library constructed around restriction sites for example, or an unfragmented small RNA library) then the constrained start sites will generate huge dupliction levels which should not be treated as a problem, nor removed by deduplication. In these types of library you should consider using a system such as random barcoding to allow the distinction of technical and biological duplicates.\n')
-        out_file.write('-'*100)
-        out_file.write('\n')
+        out_file.writelines(f"""**SEQUENCE DUPLICATION LEVELS**
+WARNING: {str(sequence_duplication_levels_list.count('warn'))} out of {str(len(sequence_duplication_levels_list))} produced WARN ({str(sequence_duplication_levels_list.count('warn')/len(sequence_duplication_levels_list)*100)}%)
+FAILURE: {str(sequence_duplication_levels_list.count('fail'))} out of {str(len(sequence_duplication_levels_list))} produced FAIL ({str(sequence_duplication_levels_list.count('fail')/len(sequence_duplication_levels_list)*100)}%)
+
+This module will issue a warning if non-unique sequences make up more than 20% of the total.
+This module will issue a error if non-unique sequences make up more than 50% of the total.
+
+Common reasons for warnings:
+The underlying assumption of this module is of a diverse unenriched library. Any deviation from this assumption will naturally generate duplicates and can lead to warnings or errors from this module.
+        
+In general there are two potential types of duplicate in a library, technical duplicates arising from PCR artefacts, or biological duplicates which are natural collisions where different copies of exactly the same sequence are randomly selected. From a sequence level there is no way to distinguish between these two types and both will be reported as duplicates here.
+        
+A warning or error in this module is simply a statement that you have exhausted the diversity in at least part of your library and are re-sequencing the same sequences. In a supposedly diverse library this would suggest that the diversity has been partially or completely exhausted and that you are therefore wasting sequencing capacity. However in some library types you will naturally tend to over-sequence parts of the library and therefore generate duplication and will therefore expect to see warnings or error from this module.
+        
+In RNA-Seq libraries sequences from different transcripts will be present at wildly different levels in the starting population. In order to be able to observe lowly expressed transcripts it is therefore common to greatly over-sequence high expressed transcripts, and this will potentially create large set of duplicates. This will result in high overall duplication in this test, and will often produce peaks in the higher duplication bins. This duplication will come from physically connected regions, and an examination of the distribution of duplicates in a specific genomic region will allow the distinction between over-sequencing and general technical duplication, but these distinctions are not possible from raw fastq files. A similar situation can arise in highly enriched ChIP-Seq libraries although the duplication there is less pronounced. Finally, if you have a library where the sequence start points are constrained (a library constructed around restriction sites for example, or an unfragmented small RNA library) then the constrained start sites will generate huge dupliction levels which should not be treated as a problem, nor removed by deduplication. In these types of library you should consider using a system such as random barcoding to allow the distinction of technical and biological duplicates.
+{'-'*100}
+""")
 
       # OVERREPRESENTED SEQUENCES
       if "warn" in overrepresented_sequences_list or "fail" in overrepresented_sequences_list:
 
-        out_file.write("**OVERREPRESENTED SEQUENCES**\n")
-        out_file.write(f"WARNING: {str(overrepresented_sequences_list.count('warn'))} out of {str(len(overrepresented_sequences_list))} produced WARN ({str(overrepresented_sequences_list.count('warn')/len(overrepresented_sequences_list)*100)}%)\n")
-        out_file.write(f"FAILURE: {str(overrepresented_sequences_list.count('fail'))} out of {str(len(overrepresented_sequences_list))} produced FAIL ({str(overrepresented_sequences_list.count('fail')/len(overrepresented_sequences_list)*100)}%)\n")
-        out_file.write('\n')
-        out_file.write('This module will issue a warning if any sequence is found to represent more than 0.1% of the total.\n')
-        out_file.write('This module will issue an error if any sequence is found to represent more than 1% of the total.\n')
-        out_file.write('\n')
-        out_file.write('Common reasons for warnings:\n')
-        out_file.write('This module will often be triggered when used to analyse small RNA libraries where sequences are not subjected to random fragmentation, and the same sequence may natrually be present in a significant proportion of the library.\n')
-        out_file.write('-'*100)
-        out_file.write('\n')
+        out_file.writelines(f"""**OVERREPRESENTED SEQUENCES**
+WARNING: {str(overrepresented_sequences_list.count('warn'))} out of {str(len(overrepresented_sequences_list))} produced WARN ({str(overrepresented_sequences_list.count('warn')/len(overrepresented_sequences_list)*100)}%)
+FAILURE: {str(overrepresented_sequences_list.count('fail'))} out of {str(len(overrepresented_sequences_list))} produced FAIL ({str(overrepresented_sequences_list.count('fail')/len(overrepresented_sequences_list)*100)}%)
+        
+This module will issue a warning if any sequence is found to represent more than 0.1% of the total.
+This module will issue an error if any sequence is found to represent more than 1% of the total.
+        
+Common reasons for warnings:
+This module will often be triggered when used to analyse small RNA libraries where sequences are not subjected to random fragmentation, and the same sequence may natrually be present in a significant proportion of the library.
+{'-'*100}
+""")
 
       # ADAPTER CONTENT
       if "warn" in adapter_content_list or "fail" in adapter_content_list:
 
-        out_file.write("**ADAPTER CONTENT**\n")
-        out_file.write(f"WARNING: {str(adapter_content_list.count('warn'))} out of {str(len(adapter_content_list))} produced WARN ({str(adapter_content_list.count('warn')/len(adapter_content_list)*100)}%)\n")
-        out_file.write(f"FAILURE: {str(adapter_content_list.count('fail'))} out of {str(len(adapter_content_list))} produced FAIL ({str(adapter_content_list.count('fail')/len(adapter_content_list)*100)}%)\n")
-        out_file.write('\n')
-        out_file.write('This module will issue a warning if any sequence is present in more than 5% of all reads.\n')
-        out_file.write('This module will issue an error if any sequence is present in more than 10% of all reads.\n')
-        out_file.write('\n')
-        out_file.write('Common reasons for warnings:\n')
-        out_file.write('Any library where a reasonable proportion of the insert sizes are shorter than the read length will trigger this module. This does not indicate a problem as such - just that the sequences will need to be adapter trimmed before proceeding with any downstream analysis.\n')
-        out_file.write('-'*100)
-        out_file.write('\n')
+        out_file.writelines(f"""**ADAPTER CONTENT**
+WARNING: {str(adapter_content_list.count('warn'))} out of {str(len(adapter_content_list))} produced WARN ({str(adapter_content_list.count('warn')/len(adapter_content_list)*100)}%)\n")
+FAILURE: {str(adapter_content_list.count('fail'))} out of {str(len(adapter_content_list))} produced FAIL ({str(adapter_content_list.count('fail')/len(adapter_content_list)*100)}%)\n")
+        
+This module will issue a warning if any sequence is present in more than 5% of all reads.
+This module will issue an error if any sequence is present in more than 10% of all reads.
+        
+Common reasons for warnings:
+Any library where a reasonable proportion of the insert sizes are shorter than the read length will trigger this module. This does not indicate a problem as such - just that the sequences will need to be adapter trimmed before proceeding with any downstream analysis.
+{'-'*100}
+""")
 
       out_file.write('source: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/')
     with open(output["warning_file"], "r") as out_file:
@@ -427,7 +449,8 @@ rule multiqc_after_trim:
   input:
     "fastqc_after_trim"
   output:
-    directory("multiqc_after_trim")
+    out_directory=directory("multiqc_after_trim"),
+    report="multiqc_after_trim.txt"
   log:
     "logs/multiqc_after_trim.log"
   params:
@@ -436,8 +459,9 @@ rule multiqc_after_trim:
     1
   shell:
     """
-    mkdir {output} &> {log}
-    multiqc -o {output} {input} &>> {log}
+    mkdir {output.out_directory} &> {log}
+    multiqc -o {output.out_directory} {input} &>> {log}
+    cp multiqc_after_trim/multiqc_data/multiqc_fastqc.txt {output.report} &>> {log}
     """
 
 rule compare_qc_after_trim:
@@ -447,8 +471,8 @@ rule compare_qc_after_trim:
   OVERREPRESENTED SEQUENCES and ADAPTER CONTENT modules of FastQC.
   """
   input:
-    before="multiqc_before_trim/multiqc_data/multiqc_fastqc.txt",
-    after="multiqc_after_trim/multiqc_data/multiqc_fastqc.txt"
+    before="multiqc_before_trim.txt",
+    after="multiqc_after_trim.txt"
   output:
     result="FastQC_comparison_after_trim.txt"
   log:
@@ -489,7 +513,13 @@ rule compare_qc_after_trim:
         adapter_content_list = []
 
         for line in data:
-          basic_statistics, per_base_sequence_quality, per_tile_sequence_quality, per_sequence_quality_scores, per_base_sequence_content, per_sequence_gc_content, per_base_n_content, sequence_length_distribution, sequence_duplication_levels, overrepresented_sequences, adapter_content = line.split("\t")[10:]
+          # per-tile module not present in report
+          if len(line.split("\t")[10:]) == 10:
+            basic_statistics, per_base_sequence_quality, per_sequence_quality_scores, per_base_sequence_content, per_sequence_gc_content, per_base_n_content, sequence_length_distribution, sequence_duplication_levels, overrepresented_sequences, adapter_content = line.split("\t")[10:]
+            per_tile_sequence_quality = ""
+          # per-tile module present in report
+          else:
+            basic_statistics, per_base_sequence_quality, per_tile_sequence_quality, per_sequence_quality_scores, per_base_sequence_content, per_sequence_gc_content, per_base_n_content, sequence_length_distribution, sequence_duplication_levels, overrepresented_sequences, adapter_content = line.split("\t")[10:]
           per_base_sequence_quality_list.append(per_base_sequence_quality)
           per_sequence_quality_scores_list.append(per_sequence_quality_scores)
           overrepresented_sequences_list.append(overrepresented_sequences)

--- a/Snakefile
+++ b/Snakefile
@@ -22,7 +22,8 @@ TRINITY_HOME=os.path.dirname(os.path.join(os.path.dirname(TRINITY_EXECUTABLE_PAT
 # https://github.com/griffithlab/rnaseq_tutorial/wiki/Trinity-Assembly-And-Analysis
 
 # These rules don't need to be sent to a cluster
-localrules: all, clean, trimmomatic_split, trimmomatic_merge, samples_yaml_conversion, trinity_butterfly_split, transcriptome_copy
+localrules: all, clean, trimmomatic_split, trimmomatic_merge, samples_yaml_conversion, trinity_butterfly_split, transcriptome_copy, compare_qc_after_trim, fastqc_before_trim_warnings
+
 
 rule all:
   """
@@ -39,7 +40,9 @@ rule all:
     "transcriptome_TPM_blast.csv",
     "fastqc",
     "multiqc",
-    "edgeR_trans"
+    "edgeR_trans",
+    "WARNING_fastqc_before_trim_overview.txt",
+    "FastQC_comparison_after_trim.txt"
 
 
 rule clean:
@@ -101,7 +104,221 @@ rule multiqc_before_trim:
     multiqc -o {output} {input} &>> {log}
     """
 
+rule fastqc_before_trim_warnings:
+  """
+  Prints warnings for FastQC modules which produced some warnings or fails of the input data.
+  """
+  input:
+    fastqc_report="multiqc_before_trim/multiqc_data/multiqc_fastqc.txt"
+  output:
+    warning_file="WARNING_fastqc_before_trim_overview.txt"
+  log:
+    "logs/fastqc_before_trim_warnings.log"
+  run:
+    with open(input["fastqc_report"], "r") as input_file, open(output["warning_file"], "w") as out_file:
+      fastqc_data = [line.strip() for line in input_file.readlines()[1:]] # skip header
 
+      basic_statistics_list = []
+      per_base_sequence_quality_list = []
+      per_tile_sequence_quality_list = []
+      per_sequence_quality_scores_list = []
+      per_base_sequence_content_list = []
+      per_sequence_gc_content_list = []
+      per_base_n_content_list = []
+      sequence_length_distribution_list = []
+      sequence_duplication_levels_list = []
+      overrepresented_sequences_list = []
+      adapter_content_list = []
+
+      for line in fastqc_data:
+        basic_statistics, per_base_sequence_quality, per_tile_sequence_quality, per_sequence_quality_scores, per_base_sequence_content, per_sequence_gc_content, per_base_n_content, sequence_length_distribution, sequence_duplication_levels, overrepresented_sequences, adapter_content = line.split("\t")[10:]
+        basic_statistics_list.append(basic_statistics)
+        per_base_sequence_quality_list.append(per_base_sequence_quality)
+        per_tile_sequence_quality_list.append(per_tile_sequence_quality)
+        per_sequence_quality_scores_list.append(per_sequence_quality_scores)
+        per_base_sequence_content_list.append(per_base_sequence_content)
+        per_sequence_gc_content_list.append(per_sequence_gc_content)
+        per_base_n_content_list.append(per_base_n_content)
+        sequence_length_distribution_list.append(sequence_length_distribution)
+        sequence_duplication_levels_list.append(sequence_duplication_levels)
+        overrepresented_sequences_list.append(overrepresented_sequences)
+        adapter_content_list.append(adapter_content)
+    
+
+      out_file.write("FASTQC MODULES WHICH PRODUCED SOME WARNINGS OR FAILS\n\n")
+      out_file.write("!!!Please check MultiQC output for interpretation of your data!!!\n")
+      out_file.write('-'*100)
+      out_file.write('\n')
+      # BASIC STATISTICS never produce warnings or fails
+
+      # PER BASE SEQUENCE QUALITY
+      if "warn" in per_base_sequence_quality_list or "fail" in per_base_sequence_quality_list:
+
+        out_file.write("**PER BASE SEQUENCE QUALITY**\n")
+        out_file.write(f"WARNING: {str(per_base_sequence_quality_list.count('warn'))} out of {str(len(per_base_sequence_quality_list))} produced WARN ({str(per_base_sequence_quality_list.count('warn')/len(per_base_sequence_quality_list)*100)}%)\n")
+        out_file.write(f"FAILURE: {str(per_base_sequence_quality_list.count('fail'))} out of {str(len(per_base_sequence_quality_list))} produced FAIL ({str(per_base_sequence_quality_list.count('fail')/len(per_base_sequence_quality_list)*100)}%)\n")
+
+        out_file.write("\n")
+        out_file.write('A warning is issued if the lower quartile for any base is less than 10, or if the median for any base is less than 25.\n')
+        out_file.write('This module will raise a failure if the lower quartile for any base is less than 5 or if the median for any base is less than 20.\n')
+        out_file.write("\n")
+        out_file.write('Common reasons for warnings:\n')
+        out_file.write('The most common reason for warnings and failures in this module is a general degradation of quality over the duration of long runs. In general sequencing chemistry degrades with increasing read length and for long runs you may find that the general quality of the run falls to a level where a warning or error is triggered.\n\n')
+        out_file.write('If the quality of the library falls to a low level then the most common remedy is to perform quality trimming where reads are truncated based on their average quality. For most libraries where this type of degradation has occurred you will often be simultaneously running into the issue of adapter read-through so a combined adapter and quality trimming step is often employed.\n\n')
+        out_file.write('Another possibility is that a warn / error is triggered because of a short loss of quality earlier in the run, which then recovers to produce later good quality sequence. This can happen if there is a transient problem with the run (bubbles passing through a flowcell for example). You can normally see this type of error by looking at the per-tile quality plot (if available for your platform). In these cases trimming is not advisable as it will remove later good sequence, but you might want to consider masking bases during subsequent mapping or assembly.\n\n')
+        out_file.write('If your library has reads of varying length then you can find a warning or error is triggered from this module because of very low coverage for a given base range. Before committing to any action, check how many sequences were responsible for triggering an error by looking at the sequence length distribution module results.\n')
+        out_file.write('-'*100)
+        out_file.write('\n')
+
+      # PER TILE SEQUENCE QUALITY
+      if "warn" in per_tile_sequence_quality_list or "fail" in per_tile_sequence_quality_list:
+
+        out_file.write("**PER TILE SEQUENCE QUALITY**\n")
+        out_file.write(f"WARNING: {str(per_tile_sequence_quality_list.count('warn'))} out of {str(len(per_tile_sequence_quality_list))} produced WARN ({str(per_tile_sequence_quality_list.count('warn')/len(per_tile_sequence_quality_list)*100)}%)\n")
+        out_file.write(f"FAILURE: {str(per_tile_sequence_quality_list.count('fail'))} out of {str(len(per_tile_sequence_quality_list))} produced FAIL ({str(per_tile_sequence_quality_list.count('fail')/len(per_tile_sequence_quality_list)*100)}%)\n")
+        out_file.write('\n')
+        out_file.write('This module issues a warning if any tile shows a mean Phred score more than 2 less than the mean for that base across all tiles.\n')
+        out_file.write('This module will issue a warning if any tile shows a mean Phred score more than 5 less than the mean for that base across all tiles.\n')
+        out_file.write('\n')
+        out_file.write('Common reasons for warnings:\n')
+        out_file.write('Whilst warnings in this module can be triggered by individual specific events we have also observed that greater variation in the phred scores attributed to tiles can also appear when a flowcell is generally overloaded. In this case events appear all over the flowcell rather than being confined to a specific area or range of cycles. We would generally ignore errors which mildly affected a small number of tiles for only 1 or 2 cycles, but would pursue larger effects which showed high deviation in scores, or which persisted for several cycles.\n')
+        out_file.write('-'*100)
+        out_file.write('\n')
+
+      # PER SEQUENCE QUALITY SCORES
+      if "warn" in per_sequence_quality_scores_list or "fail" in per_sequence_quality_scores_list:
+
+        out_file.write("**PER SEQUENCE QUALITY SCORES**\n")
+        out_file.write(f"WARNING: {str(per_sequence_quality_scores_list.count('warn'))} out of {str(len(per_sequence_quality_scores_list))} produced WARN ({str(per_sequence_quality_scores_list.count('warn')/len(per_sequence_quality_scores_list)*100)}%)\n")
+        out_file.write(f"FAILURE: {str(per_sequence_quality_scores_list.count('fail'))} out of {str(len(per_sequence_quality_scores_list))} produced FAIL ({str(per_sequence_quality_scores_list.count('fail')/len(per_sequence_quality_scores_list)*100)}%)\n")
+        out_file.write('\n')
+        out_file.write("A warning is raised if the most frequently observed mean quality is below 27 - this equates to a 0.2% error rate.\n")
+        out_file.write('An error is raised if the most frequently observed mean quality is below 20 - this equates to a 1% error rate.\n')
+        out_file.write('\n')
+        out_file.write('Common reasons for warnings:\n')
+        out_file.write('This module is generally fairly robust and errors here usually indicate a general loss of quality within a run. For long runs this may be alleviated through quality trimming. If a bi-modal, or complex distribution is seen then the results should be evaluated in concert with the per-tile qualities (if available) since this might indicate the reason for the loss in quality of a subset of sequences.\n')
+        out_file.write('-'*100)
+        out_file.write('\n')
+
+      # PER BASE SEQUENCE CONTENT
+      if "warn" in per_base_sequence_content_list or "fail" in per_base_sequence_content_list:
+
+        out_file.write("**PER BASE SEQUENCE CONTENT**\n")
+        out_file.write(f"WARNING: {str(per_base_sequence_content_list.count('warn'))} out of {str(len(per_base_sequence_content_list))} produced WARN ({str(per_base_sequence_content_list.count('warn')/len(per_base_sequence_content_list)*100)}%)\n")
+        out_file.write(f"FAILURE: {str(per_base_sequence_content_list.count('fail'))} out of {str(len(per_base_sequence_content_list))} produced FAIL ({str(per_base_sequence_content_list.count('fail')/len(per_base_sequence_content_list)*100)}%)\n")
+        out_file.write('\n')
+        out_file.write('A warning will be issued if the lower quartile for any base is less than 10, or if the median for any base is less than 25.\n')
+        out_file.write('This module will raise a failure if the lower quartile for any base is less than 5 or if the median for any base is less than 20.\n')
+        out_file.write('\n')
+        out_file.write('Common reasons for warnings:\n')
+        out_file.write('The most common reason for warnings and failures in this module is a general degradation of quality over the duration of long runs. In general sequencing chemistry degrades with increasing read length and for long runs you may find that the general quality of the run falls to a level where a warning or error is triggered.\n\n')
+        out_file.write('If the quality of the library falls to a low level then the most common remedy is to perform quality trimming where reads are truncated based on their average quality. For most libraries where this type of degradation has occurred you will often be simultaneously running into the issue of adapter read-through so a combined adapter and quality trimming step is often employed.\n\n')
+        out_file.write('Another possibility is that a warn / error is triggered because of a short loss of quality earlier in the run, which then recovers to produce later good quality sequence. This can happen if there is a transient problem with the run (bubbles passing through a flowcell for example). You can normally see this type of error by looking at the per-tile quality plot (if available for your platform). In these cases trimming is not advisable as it will remove later good sequence, but you might want to consider masking bases during subsequent mapping or assembly.\n\n')
+        out_file.write('If your library has reads of varying length then you can find a warning or error is triggered from this module because of very low coverage for a given base range. Before committing to any action, check how many sequences were responsible for triggering an error by looking at the sequence length distribution module results.\n')
+        out_file.write('-'*100)
+        out_file.write('\n')
+
+      # PER SEQUENCE GC CONTENT
+      if "warn" in per_sequence_gc_content_list or "fail" in per_sequence_gc_content_list:
+
+        out_file.write("**PER SEQUENCE GC CONTENT**\n")
+        out_file.write(f"WARNING: {str(per_sequence_gc_content_list.count('warn'))} out of {str(len(per_sequence_gc_content_list))} produced WARN ({str(per_sequence_gc_content_list.count('warn')/len(per_sequence_gc_content_list)*100)}%)\n")
+        out_file.write(f"FAILURE: {str(per_sequence_gc_content_list.count('fail'))} out of {str(len(per_sequence_gc_content_list))} produced FAIL ({str(per_sequence_gc_content_list.count('fail')/len(per_sequence_gc_content_list)*100)}%)\n")
+        out_file.write('\n')
+        out_file.write('A warning is raised if the sum of the deviations from the normal distribution represents more than 15% of the reads.\n')
+        out_file.write('This module will indicate a failure if the sum of the deviations from the normal distribution represents more than 30% of the reads.\n')
+        out_file.write('\n')
+        out_file.write('Common reasons for warnings:\n')
+        out_file.write('Warnings in this module usually indicate a problem with the library. Sharp peaks on an otherwise smooth distribution are normally the result of a specific contaminant (adapter dimers for example), which may well be picked up by the overrepresented sequences module. Broader peaks may represent contamination with a different species.\n')
+        out_file.write('-'*100)
+        out_file.write('\n')
+
+      # PER BASE N CONTENT
+      if "warn" in per_base_n_content_list or "fail" in per_base_n_content_list:
+
+        out_file.write("**PER BASE N CONTENT**\n")
+        out_file.write(f"WARNING: {str(per_base_n_content_list.count('warn'))} out of {str(len(per_base_n_content_list))} produced WARN ({str(per_base_n_content_list.count('warn')/len(per_base_n_content_list)*100)}%)\n")
+        out_file.write(f"FAILURE: {str(per_base_n_content_list.count('fail'))} out of {str(len(per_base_n_content_list))} produced FAIL ({str(per_base_n_content_list.count('fail')/len(per_base_n_content_list)*100)}%)\n")
+        out_file.write('\n')
+        out_file.write('This module raises a warning if any position shows an N content of >5%.\n')
+        out_file.write('This module will raise an error if any position shows an N content of >20%.\n')
+        out_file.write('\n')
+        out_file.write('Common reasons for warnings:\n')
+        out_file.write('The most common reason for the inclusion of significant proportions of Ns is a general loss of quality, so the results of this module should be evaluated in concert with those of the various quality modules. You should check the coverage of a specific bin, since it is possible that the last bin in this analysis could contain very few sequences, and an error could be prematurely triggered in this case.\n\n')
+        out_file.write('Another common scenario is the incidence of a high proportions of N at a small number of positions early in the library, against a background of generally good quality. Such deviations can occur when you have very biased sequence composition in the library to the point that base callers can become confused and make poor calls. This type of problem will be apparent when looking at the per-base sequence content results.\n')
+        out_file.write('-'*100)
+        out_file.write('\n')
+
+      # SEQUENCE LENGTH DISTRIBUTION
+      if "warn" in sequence_length_distribution_list or "fail" in sequence_length_distribution_list:
+
+        out_file.write("**SEQUENCE LENGTH DISTRIBUTION**\n")
+        out_file.write(f"WARNING: {str(sequence_length_distribution_list.count('warn'))} out of {str(len(sequence_length_distribution_list))} produced WARN ({str(sequence_length_distribution_list.count('warn')/len(sequence_length_distribution_list)*100)}%)\n")
+        out_file.write(f"FAILURE: {str(sequence_length_distribution_list.count('fail'))} out of {str(len(sequence_length_distribution_list))} produced FAIL ({str(sequence_length_distribution_list.count('fail')/len(sequence_length_distribution_list)*100)}%)\n")
+        out_file.write('\n')
+        out_file.write('This module will raise a warning if all sequences are not the same length.\n')
+        out_file.write('This module will raise an error if any of the sequences have zero length.\n')
+        out_file.write('\n')
+        out_file.write('Common reasons for warnings:\n')
+        out_file.write('For some sequencing platforms it is entirely normal to have different read lengths so warnings here can be ignored.\n')
+        out_file.write('-'*100)
+        out_file.write('\n')
+
+      # SEQUENCE DUPLICATION LEVELS
+      if "warn" in sequence_duplication_levels_list or "fail" in sequence_duplication_levels_list:
+
+        out_file.write("**SEQUENCE DUPLICATION LEVELS**\n")
+        out_file.write(f"WARNING: {str(sequence_duplication_levels_list.count('warn'))} out of {str(len(sequence_duplication_levels_list))} produced WARN ({str(sequence_duplication_levels_list.count('warn')/len(sequence_duplication_levels_list)*100)}%)\n")
+        out_file.write(f"FAILURE: {str(sequence_duplication_levels_list.count('fail'))} out of {str(len(sequence_duplication_levels_list))} produced FAIL ({str(sequence_duplication_levels_list.count('fail')/len(sequence_duplication_levels_list)*100)}%)\n")
+        out_file.write('\n')
+        out_file.write('This module will issue a warning if non-unique sequences make up more than 20% of the total.\n')
+        out_file.write('This module will issue a error if non-unique sequences make up more than 50% of the total.\n')
+        out_file.write('\n')
+        out_file.write('Common reasons for warnings:\n')
+        out_file.write('The underlying assumption of this module is of a diverse unenriched library. Any deviation from this assumption will naturally generate duplicates and can lead to warnings or errors from this module.\n\n')
+        out_file.write('In general there are two potential types of duplicate in a library, technical duplicates arising from PCR artefacts, or biological duplicates which are natural collisions where different copies of exactly the same sequence are randomly selected. From a sequence level there is no way to distinguish between these two types and both will be reported as duplicates here.\n\n')
+        out_file.write('A warning or error in this module is simply a statement that you have exhausted the diversity in at least part of your library and are re-sequencing the same sequences. In a supposedly diverse library this would suggest that the diversity has been partially or completely exhausted and that you are therefore wasting sequencing capacity. However in some library types you will naturally tend to over-sequence parts of the library and therefore generate duplication and will therefore expect to see warnings or error from this module.\n\n')
+        out_file.write('In RNA-Seq libraries sequences from different transcripts will be present at wildly different levels in the starting population. In order to be able to observe lowly expressed transcripts it is therefore common to greatly over-sequence high expressed transcripts, and this will potentially create large set of duplicates. This will result in high overall duplication in this test, and will often produce peaks in the higher duplication bins. This duplication will come from physically connected regions, and an examination of the distribution of duplicates in a specific genomic region will allow the distinction between over-sequencing and general technical duplication, but these distinctions are not possible from raw fastq files. A similar situation can arise in highly enriched ChIP-Seq libraries although the duplication there is less pronounced. Finally, if you have a library where the sequence start points are constrained (a library constructed around restriction sites for example, or an unfragmented small RNA library) then the constrained start sites will generate huge dupliction levels which should not be treated as a problem, nor removed by deduplication. In these types of library you should consider using a system such as random barcoding to allow the distinction of technical and biological duplicates.\n')
+        out_file.write('-'*100)
+        out_file.write('\n')
+
+      # OVERREPRESENTED SEQUENCES
+      if "warn" in overrepresented_sequences_list or "fail" in overrepresented_sequences_list:
+
+        out_file.write("**OVERREPRESENTED SEQUENCES**\n")
+        out_file.write(f"WARNING: {str(overrepresented_sequences_list.count('warn'))} out of {str(len(overrepresented_sequences_list))} produced WARN ({str(overrepresented_sequences_list.count('warn')/len(overrepresented_sequences_list)*100)}%)\n")
+        out_file.write(f"FAILURE: {str(overrepresented_sequences_list.count('fail'))} out of {str(len(overrepresented_sequences_list))} produced FAIL ({str(overrepresented_sequences_list.count('fail')/len(overrepresented_sequences_list)*100)}%)\n")
+        out_file.write('\n')
+        out_file.write('This module will issue a warning if any sequence is found to represent more than 0.1% of the total.\n')
+        out_file.write('This module will issue an error if any sequence is found to represent more than 1% of the total.\n')
+        out_file.write('\n')
+        out_file.write('Common reasons for warnings:\n')
+        out_file.write('This module will often be triggered when used to analyse small RNA libraries where sequences are not subjected to random fragmentation, and the same sequence may natrually be present in a significant proportion of the library.\n')
+        out_file.write('-'*100)
+        out_file.write('\n')
+
+      # ADAPTER CONTENT
+      if "warn" in adapter_content_list or "fail" in adapter_content_list:
+
+        out_file.write("**ADAPTER CONTENT**\n")
+        out_file.write(f"WARNING: {str(adapter_content_list.count('warn'))} out of {str(len(adapter_content_list))} produced WARN ({str(adapter_content_list.count('warn')/len(adapter_content_list)*100)}%)\n")
+        out_file.write(f"FAILURE: {str(adapter_content_list.count('fail'))} out of {str(len(adapter_content_list))} produced FAIL ({str(adapter_content_list.count('fail')/len(adapter_content_list)*100)}%)\n")
+        out_file.write('\n')
+        out_file.write('This module will issue a warning if any sequence is present in more than 5% of all reads.\n')
+        out_file.write('This module will issue an error if any sequence is present in more than 10% of all reads.\n')
+        out_file.write('\n')
+        out_file.write('Common reasons for warnings:\n')
+        out_file.write('Any library where a reasonable proportion of the insert sizes are shorter than the read length will trigger this module. This does not indicate a problem as such - just that the sequences will need to be adapter trimmed before proceeding with any downstream analysis.\n')
+        out_file.write('-'*100)
+        out_file.write('\n')
+
+      out_file.write('source: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/')
+    with open(output["warning_file"], "r") as out_file:
+      for line in out_file.readlines():
+        print(line.strip())
+      print('See this output in WARNING_fastqc_before_trim_overview.txt')
+
+    
 checkpoint trimmomatic_split:
   """
   Splits file with information about all reads files into separate files
@@ -224,187 +441,106 @@ rule multiqc_after_trim:
     """
 
 rule compare_qc_after_trim:
-"""
-Compares the quality of reads before and after trimming.
-"""
-input:
-  before="multiqc_before_trim/multiqc_data/multiqc_fastqc.txt",
-  after="multiqc_after_trim/multiqc_data/multiqc_fastqc.txt"
-output:
-  result="qc_comparison.txt"
-log:
-  "logs/compare_qc_after_trim.log"
-run:
-  with open(input["before"], "r") as before, open(input["after"], "r") as after, open(output["result"], "w") as out:
-    before_data = before.readlines()[1:] # skip header
-    after_data = after.readlines()[1:] # skip header
+  """
+  Compares the quality of reads before and after trimming.
+  Compares PER BASE SEQUENCE QUALITY, PER SEQUENCE QUALITY SCORES, 
+  OVERREPRESENTED SEQUENCES and ADAPTER CONTENT modules of FastQC.
+  """
+  input:
+    before="multiqc_before_trim/multiqc_data/multiqc_fastqc.txt",
+    after="multiqc_after_trim/multiqc_data/multiqc_fastqc.txt"
+  output:
+    result="FastQC_comparison_after_trim.txt"
+  log:
+    "logs/compare_qc_after_trim.log"
+  run:
+ 
+    with open(input["before"], "r") as before, open(input["after"], "r") as after, open(output["result"], "w") as out_file:
+      before_data = [line.strip() for line in before.readlines()[1:]] # skip header
+      after_data = [line.strip() for line in after.readlines()[1:]] # skip header
 
-    basic_statistics_list = []
-    per_base_sequence_quality_list = []
-    per_tile_sequence_quality_list = []
-    per_sequence_quality_scores_list = []
-    per_base_sequence_content_list = []
-    per_sequence_gc_content_list = []
-    per_base_n_content_list = []
-    sequence_length_distribution_list = []
-    sequence_duplication_levels_list = []
-    overrepresented_sequences_list = []
-    adapter_content_list = []
+      per_base_sequence_quality_list = []
+      per_sequence_quality_scores_list = []
+      overrepresented_sequences_list = []
+      adapter_content_list = []
 
-    for line in before_data:
-      basic_statistics, per_base_sequence_quality, per_tile_sequence_quality, per_sequence_quality_scores, per_base_sequence_content, per_sequence_gc_content, per_base_n_content, sequence_length_distribution, sequence_duplication_levels, overrepresented_sequences, adapter_content = line.split("\t")[10:]
-      basic_statistics_list.append(basic_statistics)
-      per_base_sequence_quality_list.append(per_base_sequence_quality)
-      per_tile_sequence_quality_list.append(per_tile_sequence_quality)
-      per_sequence_quality_scores_list.append(per_sequence_quality_scores)
-      per_base_sequence_content_list.append(per_base_sequence_content)
-      per_sequence_gc_content_list.append(per_sequence_gc_content)
-      per_base_n_content_list.append(per_base_n_content)
-      sequence_length_distribution_list.append(sequence_length_distribution)
-      sequence_duplication_levels_list.append(sequence_duplication_levels)
-      overrepresented_sequences_list.append(overrepresented_sequences)
-      adapter_content_list.append(adapter_content)
+      for line in before_data:
+        basic_statistics, per_base_sequence_quality, per_tile_sequence_quality, per_sequence_quality_scores, per_base_sequence_content, per_sequence_gc_content, per_base_n_content, sequence_length_distribution, sequence_duplication_levels, overrepresented_sequences, adapter_content = line.split("\t")[10:]
+        per_base_sequence_quality_list.append(per_base_sequence_quality)
+        per_sequence_quality_scores_list.append(per_sequence_quality_scores)
+        overrepresented_sequences_list.append(overrepresented_sequences)
+        adapter_content_list.append(adapter_content)
     
-    basic_statistics_list_after = []
-    per_base_sequence_quality_list_after = []
-    per_tile_sequence_quality_list_after = []
-    per_sequence_quality_scores_list_after = []
-    per_base_sequence_content_list_after = []
-    per_sequence_gc_content_list_after = []
-    per_base_n_content_list_after = []
-    sequence_length_distribution_list_after = []
-    sequence_duplication_levels_list_after = []
-    overrepresented_sequences_list_after = []
-    adapter_content_list_after = []
+      per_base_sequence_quality_list_after = []
+      per_sequence_quality_scores_list_after = []
+      overrepresented_sequences_list_after = []
+      adapter_content_list_after = []
   
-  for line in after_data:
-    basic_statistics_after, per_base_sequence_quality_after, per_tile_sequence_quality_after, per_sequence_quality_scores_after, per_base_sequence_content_after, per_sequence_gc_content_after, per_base_n_content_after, sequence_length_distribution_after, sequence_duplication_levels_after, overrepresented_sequences_after, adapter_content_after = line.split("\t")[10:]
-    basic_statistics_list_after.append(basic_statistics_after)
-    per_base_sequence_quality_list_after.append(per_base_sequence_quality_after)
-    per_tile_sequence_quality_list_after.append(per_tile_sequence_quality_after)
-    per_sequence_quality_scores_list_after.append(per_sequence_quality_scores_after)
-    per_base_sequence_content_list_after.append(per_base_sequence_content_after)
-    per_sequence_gc_content_list_after.append(per_sequence_gc_content_after)
-    per_base_n_content_list_after.append(per_base_n_content_after)
-    sequence_length_distribution_list_after.append(sequence_length_distribution_after)
-    sequence_duplication_levels_list_after.append(sequence_duplication_levels_after)
-    overrepresented_sequences_list_after.append(overrepresented_sequences_after)
-    adapter_content_list_after.append(adapter_content_after)
-  
-  out.write("FastQC comparison before and after trimming\n")
-  out.write("BASIC STATISTICS\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(basic_statistics_list.count('pass')) + '\n')
-  out.write("warn: " + str(basic_statistics_list.count('warn')) + '\n')
-  out.write("fail: " + str(basic_statistics_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(basic_statistics_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(basic_statistics_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(basic_statistics_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
-  out.write("PER BASE SEQUENCE QUALITY\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(per_base_sequence_quality_list.count('pass')) + '\n')
-  out.write("warn: " + str(per_base_sequence_quality_list.count('warn')) + '\n')
-  out.write("fail: " + str(per_base_sequence_quality_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(per_base_sequence_quality_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(per_base_sequence_quality_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(per_base_sequence_quality_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
-  out.write("PER TILE SEQUENCE QUALITY\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(per_tile_sequence_quality_list.count('pass')) + '\n')
-  out.write("warn: " + str(per_tile_sequence_quality_list.count('warn')) + '\n')
-  out.write("fail: " + str(per_tile_sequence_quality_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(per_tile_sequence_quality_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(per_tile_sequence_quality_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(per_tile_sequence_quality_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
-  out.write("PER SEQUENCE QUALITY SCORES\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(per_sequence_quality_scores_list.count('pass')) + '\n')
-  out.write("warn: " + str(per_sequence_quality_scores_list.count('warn')) + '\n')
-  out.write("fail: " + str(per_sequence_quality_scores_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(per_sequence_quality_scores_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(per_sequence_quality_scores_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(per_sequence_quality_scores_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
-  out.write("PER BASE SEQUENCE CONTENT\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(per_base_sequence_content_list.count('pass')) + '\n')
-  out.write("warn: " + str(per_base_sequence_content_list.count('warn')) + '\n')
-  out.write("fail: " + str(per_base_sequence_content_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(per_base_sequence_content_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(per_base_sequence_content_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(per_base_sequence_content_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
-  out.write("PER SEQUENCE GC CONTENT\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(per_sequence_gc_content_list.count('pass')) + '\n')
-  out.write("warn: " + str(per_sequence_gc_content_list.count('warn')) + '\n')
-  out.write("fail: " + str(per_sequence_gc_content_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(per_sequence_gc_content_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(per_sequence_gc_content_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(per_sequence_gc_content_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
-  out.write("PER BASE N CONTENT\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(per_base_n_content_list.count('pass')) + '\n')
-  out.write("warn: " + str(per_base_n_content_list.count('warn')) + '\n')
-  out.write("fail: " + str(per_base_n_content_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(per_base_n_content_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(per_base_n_content_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(per_base_n_content_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
-  out.write("SEQUENCE LENGTH DISTRIBUTION\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(sequence_length_distribution_list.count('pass')) + '\n')
-  out.write("warn: " + str(sequence_length_distribution_list.count('warn')) + '\n')
-  out.write("fail: " + str(sequence_length_distribution_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(sequence_length_distribution_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(sequence_length_distribution_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(sequence_length_distribution_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
-  out.write("SEQUENCE DUPLICATION LEVELS\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(sequence_duplication_levels_list.count('pass')) + '\n')
-  out.write("warn: " + str(sequence_duplication_levels_list.count('warn')) + '\n')
-  out.write("fail: " + str(sequence_duplication_levels_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(sequence_duplication_levels_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(sequence_duplication_levels_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(sequence_duplication_levels_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
-  out.write("OVERREPRESENTED SEQUENCES\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(overrepresented_sequences_list.count('pass')) + '\n')
-  out.write("warn: " + str(overrepresented_sequences_list.count('warn')) + '\n')
-  out.write("fail: " + str(overrepresented_sequences_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(overrepresented_sequences_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(overrepresented_sequences_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(overrepresented_sequences_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
-  out.write("ADAPTER CONTENT\n")
-  out.write("Before trimming:\n")
-  out.write("pass: " + str(adapter_content_list.count('pass')) + '\n')
-  out.write("warn: " + str(adapter_content_list.count('warn')) + '\n')
-  out.write("fail: " + str(adapter_content_list.count('fail')) + '\n')
-  out.write("After trimming:\n")
-  out.write("pass: " + str(adapter_content_list_after.count('pass')) + '\n')
-  out.write("warn: " + str(adapter_content_list_after.count('warn')) + '\n')
-  out.write("fail: " + str(adapter_content_list_after.count('fail')) + '\n')
-  out.write('-' * 50 + '\n')
+      for line in after_data:
+        basic_statistics_after, per_base_sequence_quality_after, per_tile_sequence_quality_after, per_sequence_quality_scores_after, per_base_sequence_content_after, per_sequence_gc_content_after, per_base_n_content_after, sequence_length_distribution_after, sequence_duplication_levels_after, overrepresented_sequences_after, adapter_content_after = line.split("\t")[10:]
+        per_base_sequence_quality_list_after.append(per_base_sequence_quality_after)
+        per_sequence_quality_scores_list_after.append(per_sequence_quality_scores_after)
+        overrepresented_sequences_list_after.append(overrepresented_sequences_after)
+        adapter_content_list_after.append(adapter_content_after)
+        
+      out_file.write("FASTQC COMPARISON BEFORE AND AFTER TRIMMING\n")
+      out_file.write('-' * 50 + '\n')
 
+      out_file.write("**PER BASE SEQUENCE QUALITY**\n")
+      out_file.write("Before trimming:\n")
+      out_file.write(f"pass: {str(per_base_sequence_quality_list.count('pass'))} out of {str(len(per_base_sequence_quality_list))} ({str(per_base_sequence_quality_list.count('pass')/len(per_base_sequence_quality_list)*100)}%)\n")
+      out_file.write(f"warn: {str(per_base_sequence_quality_list.count('warn'))} out of {str(len(per_base_sequence_quality_list))} ({str(per_base_sequence_quality_list.count('warn')/len(per_base_sequence_quality_list)*100)}%)\n")
+      out_file.write(f"fail: {str(per_base_sequence_quality_list.count('fail'))} out of {str(len(per_base_sequence_quality_list))} ({str(per_base_sequence_quality_list.count('fail')/len(per_base_sequence_quality_list)*100)}%)\n")
+      out_file.write('\n')
 
-    
+      out_file.write("After trimming:\n")
+      out_file.write(f"pass: {str(per_base_sequence_quality_list_after.count('pass'))} out of {str(len(per_base_sequence_quality_list_after))} ({str(per_base_sequence_quality_list_after.count('pass')/len(per_base_sequence_quality_list_after)*100)}%)\n")
+      out_file.write(f"warn: {str(per_base_sequence_quality_list_after.count('warn'))} out of {str(len(per_base_sequence_quality_list_after))} ({str(per_base_sequence_quality_list_after.count('warn')/len(per_base_sequence_quality_list_after)*100)}%)\n")
+      out_file.write(f"fail: {str(per_base_sequence_quality_list_after.count('fail'))} out of {str(len(per_base_sequence_quality_list_after))} ({str(per_base_sequence_quality_list_after.count('fail')/len(per_base_sequence_quality_list_after)*100)}%)\n")
+      out_file.write('-' * 50 + '\n')
+
+      out_file.write("**PER SEQUENCE QUALITY SCORES**\n")
+      out_file.write("Before trimming:\n")
+      out_file.write(f"pass: {str(per_sequence_quality_scores_list.count('pass'))} out of {str(len(per_sequence_quality_scores_list))} ({str(per_sequence_quality_scores_list.count('pass')/len(per_sequence_quality_scores_list)*100)}%)\n")
+      out_file.write(f"warn: {str(per_sequence_quality_scores_list.count('warn'))} out of {str(len(per_sequence_quality_scores_list))} ({str(per_sequence_quality_scores_list.count('warn')/len(per_sequence_quality_scores_list)*100)}%)\n")
+      out_file.write(f"fail: {str(per_sequence_quality_scores_list.count('fail'))} out of {str(len(per_sequence_quality_scores_list))} ({str(per_sequence_quality_scores_list.count('fail')/len(per_sequence_quality_scores_list)*100)}%)\n")
+      out_file.write('\n')
+
+      out_file.write("After trimming:\n")
+      out_file.write(f"pass: {str(per_sequence_quality_scores_list_after.count('pass'))} out of {str(len(per_sequence_quality_scores_list_after))} ({str(per_sequence_quality_scores_list_after.count('pass')/len(per_sequence_quality_scores_list_after)*100)}%)\n")
+      out_file.write(f"warn: {str(per_sequence_quality_scores_list_after.count('warn'))} out of {str(len(per_sequence_quality_scores_list_after))} ({str(per_sequence_quality_scores_list_after.count('warn')/len(per_sequence_quality_scores_list_after)*100)}%)\n")
+      out_file.write(f"fail: {str(per_sequence_quality_scores_list_after.count('fail'))} out of {str(len(per_sequence_quality_scores_list_after))} ({str(per_sequence_quality_scores_list_after.count('fail')/len(per_sequence_quality_scores_list_after)*100)}%)\n")
+      out_file.write('-' * 50 + '\n')
+
+      out_file.write("**OVERREPRESENTED SEQUENCES**\n")
+      out_file.write("Before trimming:\n")
+      out_file.write(f"pass: {str(overrepresented_sequences_list.count('pass'))} out of {str(len(overrepresented_sequences_list))} ({str(overrepresented_sequences_list.count('pass')/len(overrepresented_sequences_list)*100)}%)\n")
+      out_file.write(f"warn: {str(overrepresented_sequences_list.count('warn'))} out of {str(len(overrepresented_sequences_list))} ({str(overrepresented_sequences_list.count('warn')/len(overrepresented_sequences_list)*100)}%)\n")
+      out_file.write(f"fail: {str(overrepresented_sequences_list.count('fail'))} out of {str(len(overrepresented_sequences_list))} ({str(overrepresented_sequences_list.count('fail')/len(overrepresented_sequences_list)*100)}%)\n")
+      out_file.write('\n')
+
+      out_file.write("After trimming:\n")
+      out_file.write(f"pass: {str(overrepresented_sequences_list_after.count('pass'))} out of {str(len(overrepresented_sequences_list_after))} ({str(overrepresented_sequences_list_after.count('pass')/len(overrepresented_sequences_list_after)*100)}%)\n")
+      out_file.write(f"warn: {str(overrepresented_sequences_list_after.count('warn'))} out of {str(len(overrepresented_sequences_list_after))} ({str(overrepresented_sequences_list_after.count('warn')/len(overrepresented_sequences_list_after)*100)}%)\n")
+      out_file.write(f"fail: {str(overrepresented_sequences_list_after.count('fail'))} out of {str(len(overrepresented_sequences_list_after))} ({str(overrepresented_sequences_list_after.count('fail')/len(overrepresented_sequences_list_after)*100)}%)\n")
+      out_file.write('-' * 50 + '\n')
+
+      out_file.write("**ADAPTER CONTENT**\n")
+      out_file.write("Before trimming:\n")
+      out_file.write(f"pass: {str(adapter_content_list.count('pass'))} out of {str(len(adapter_content_list))} ({str(adapter_content_list.count('pass')/len(adapter_content_list)*100)}%)\n")
+      out_file.write(f"warn: {str(adapter_content_list.count('warn'))} out of {str(len(adapter_content_list))} ({str(adapter_content_list.count('warn')/len(adapter_content_list)*100)}%)\n")
+      out_file.write(f"fail: {str(adapter_content_list.count('fail'))} out of {str(len(adapter_content_list))} ({str(adapter_content_list.count('fail')/len(adapter_content_list)*100)}%)\n")
+      out_file.write('\n')
+
+      out_file.write("After trimming:\n")
+      out_file.write(f"pass: {str(adapter_content_list_after.count('pass'))} out of {str(len(adapter_content_list_after))} ({str(adapter_content_list_after.count('pass')/len(adapter_content_list_after)*100)}%)\n")
+      out_file.write(f"warn: {str(adapter_content_list_after.count('warn'))} out of {str(len(adapter_content_list_after))} ({str(adapter_content_list_after.count('warn')/len(adapter_content_list_after)*100)}%)\n")
+      out_file.write(f"fail: {str(adapter_content_list_after.count('fail'))} out of {str(len(adapter_content_list_after))} ({str(adapter_content_list_after.count('fail')/len(adapter_content_list_after)*100)}%)\n")
+      out_file.write('-' * 50 + '\n')
+    with open(output["result"], "r") as out_file:
+      for line in out_file.readlines():
+        print(line.strip())
+      print('See this output in FastQC_comparison_after_trim.txt')
 
 rule samples_yaml_conversion:
   """

--- a/Snakefile
+++ b/Snakefile
@@ -489,18 +489,18 @@ rule compare_qc_after_trim:
 
     # compares pass, warn, fail counts before and after trimming for a given module and writes the result to the output file
     def compare_module(module_name, before_trim, after_trim, out_file):
-      out_file.write(f'**{module_name}**\n')
-      out_file.write('Before trimming:\n')
-      out_file.write(f"pass: {str(before_trim.count('pass'))} out of {str(len(before_trim))} ({str(before_trim.count('pass')/len(before_trim)*100)}%)\n")
-      out_file.write(f"warn: {str(before_trim.count('warn'))} out of {str(len(before_trim))} ({str(before_trim.count('warn')/len(before_trim)*100)}%)\n")
-      out_file.write(f"fail: {str(before_trim.count('fail'))} out of {str(len(before_trim))} ({str(before_trim.count('fail')/len(before_trim)*100)}%)\n")
-      out_file.write('\n')
-
-      out_file.write('After trimming:\n')
-      out_file.write(f"pass: {str(after_trim.count('pass'))} out of {str(len(after_trim))} ({str(after_trim.count('pass')/len(after_trim)*100)}%)\n")
-      out_file.write(f"warn: {str(after_trim.count('warn'))} out of {str(len(after_trim))} ({str(after_trim.count('warn')/len(after_trim)*100)}%)\n")
-      out_file.write(f"fail: {str(after_trim.count('fail'))} out of {str(len(after_trim))} ({str(after_trim.count('fail')/len(after_trim)*100)}%)\n")
-      out_file.write('-' * 50 + '\n')
+      out_file.writelines(f"""**{module_name}**
+      Before trimming:
+      pass: {str(before_trim.count('pass'))} out of {str(len(before_trim))} ({str(before_trim.count('pass')/len(before_trim)*100)}%)
+      warn: {str(before_trim.count('warn'))} out of {str(len(before_trim))} ({str(before_trim.count('warn')/len(before_trim)*100)}%)
+      fail: {str(before_trim.count('fail'))} out of {str(len(before_trim))} ({str(before_trim.count('fail')/len(before_trim)*100)}%)
+      
+      After trimming:
+      pass: {str(after_trim.count('pass'))} out of {str(len(after_trim))} ({str(after_trim.count('pass')/len(after_trim)*100)}%)
+      warn: {str(after_trim.count('warn'))} out of {str(len(after_trim))} ({str(after_trim.count('warn')/len(after_trim)*100)}%)
+      fail: {str(after_trim.count('fail'))} out of {str(len(after_trim))} ({str(after_trim.count('fail')/len(after_trim)*100)}%)
+      {'-' * 50}
+      """)
     
     # reads the file with fastqc results and returns a list of pass, warn, fail values of the input files for relevant modules
     def load_data(file_name):


### PR DESCRIPTION
- Renamed rules fastqc and multiqc to fastqc_before_trim and multiqc_before_trim.

- Added new rules fastqc_before_trim_warnings, fastqc_after_trim, multtiqc_after_trim and compare_qc_after_trim.

Produces warnings for FastQC modules which produced some warnings or fails on the input data.
It prints the warning on the terminal and also produces a text file with it.
Includes explanation when the warnings and fails occur and what could cause them from [FastQC website](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/10%20Adapter%20Content.html)
The text file looks like this:

```
FASTQC MODULES WHICH PRODUCED SOME WARNINGS OR FAILS

!!!Please check MultiQC output for interpretation of your data!!!
----------------------------------------------------------------------------------------------------
**PER BASE SEQUENCE QUALITY**
WARNING: 1 out of 20 produced WARN (5.0%)
FAILURE: 4 out of 20 produced FAIL (20.0%)

A warning is issued if the lower quartile for any base is less than 10, or if the median for any base is less than 25.
This module will raise a failure if the lower quartile for any base is less than 5 or if the median for any base is less than 20.

Common reasons for warnings:
The most common reason for warnings and failures in this module is a general degradation of quality over the duration of long runs. ....

If the quality of the library ...

Another possibility ...

If your library has reads of varying length ....
----------------------------------------------------------------------------------------------------
**PER TILE SEQUENCE QUALITY**
WARNING: 4 out of 20 produced WARN (20.0%)
FAILURE: 4 out of 20 produced FAIL (20.0%)

This module issues a warning if any tile shows a mean Phred score more than 2 less than the mean for that base across all tiles.
This module will issue a warning if any tile shows a mean Phred score more than 5 less than the mean for that base across all tiles.

Common reasons for warnings:
Whilst warnings ...
----------------------------------------------------------------------------------------------------
**PER BASE SEQUENCE CONTENT**
...
```

Runs FastQC and MultiQC also after the trimming and then compares their results. 
Compares PER BASE SEQUENCE QUALITY, PER SEQUENCE QUALITY SCORES, OVERREPRESENTED SEQUENCES and ADAPTER CONTENT modules of FastQC.
It prints the warning on the terminal and also produces a text file with them.
The text file looks like this:
```
FASTQC COMPARISON BEFORE AND AFTER TRIMMING
--------------------------------------------------
**PER BASE SEQUENCE QUALITY**
Before trimming:
pass: 15 out of 20 (75.0%)
warn: 1 out of 20 (5.0%)
fail: 4 out of 20 (20.0%)

After trimming:
pass: 20 out of 20 (100.0%)
warn: 0 out of 20 (0.0%)
fail: 0 out of 20 (0.0%)
--------------------------------------------------
**PER SEQUENCE QUALITY SCORES**
Before trimming:
pass: 20 out of 20 (100.0%)
warn: 0 out of 20 (0.0%)
fail: 0 out of 20 (0.0%)

After trimming:
pass: 20 out of 20 (100.0%)
warn: 0 out of 20 (0.0%)
fail: 0 out of 20 (0.0%)
--------------------------------------------------
**OVERREPRESENTED SEQUENCES**
Before trimming:
...
```
