### PR TITLE
Add strandedness and multiple kmers options

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -736,7 +736,7 @@ rule rnaspades:
   shell:
     """
     ##TODO = kmer shouldn't be fixed, & should be configurable from the beginning of the script (did run into some bugs with the auto parameter)
-    rnaspades.py --dataset {input.samples} -t {threads} -m {params.memory} -o rnaspades_out --only-assembler -k 47 &> {log}
+    rnaspades.py --dataset {input.samples} -t {threads} -m {params.memory} -o rnaspades_out {config[strand_specific]} --only-assembler -k {config[kmers]} &> {log}
     ##Make a fake gene_trans_map file
     seqkit seq -n {output.transcriptome} | while read id ; do echo -e "$id\\t$id" ; done > {output.gene_trans_map} 2>> {log}
     """

--- a/Snakefile
+++ b/Snakefile
@@ -735,8 +735,7 @@ rule rnaspades:
     16
   shell:
     """
-    ##TODO = kmer shouldn't be fixed, & should be configurable from the beginning of the script (did run into some bugs with the auto parameter)
-    rnaspades.py --dataset {input.samples} -t {threads} -m {params.memory} -o rnaspades_out {config[strand_specific]} --only-assembler -k {config[kmers]} &> {log}
+    rnaspades.py --dataset {input.samples} -t {threads} -m {params.memory} -o rnaspades_out {config[strand_specific]} --only-assembler {config[kmers]} &> {log}
     ##Make a fake gene_trans_map file
     seqkit seq -n {output.transcriptome} | while read id ; do echo -e "$id\\t$id" ; done > {output.gene_trans_map} 2>> {log}
     """

--- a/config.yaml
+++ b/config.yaml
@@ -19,11 +19,32 @@ trinity_parameters: "--seqType fq"
 targetp: "non-pl"
 
 # Strand-specific RNA-Seq read orientation.
-# if paired: RF or FR,
-# if single: F or R.   (dUTP method = RF)
+#
+# For Trinity assembler use
+# if paired: RF or FR, (dUTP method = RF)
+# if single: F or R.   
+#
 # This parameter is used for both Trinity and read alignment steps
-# strand_specific: --SS_lib_type RF
+#
+# For example:
+# strand_specific: "--SS_lib_type RF"
+#
+# For rnaSPAdes assembler use
+# if paired: fr (normal) or rf (antisense)
+# For example:
+# strand_specific: "--ss rf"
 strand_specific: ""
+
+# For rnaSPAdes assembler select kmer sizes.
+# !!! all values must be odd, less than 128 and listed in ascending order !!!
+# For example:
+# kmers: "21,33,55"
+#
+# For Illumina 150 bp reads, it is recommended to use: 21,33,55
+# For reads between 150 and 249, it is recommended to use: 21,33,55,77
+# For 250bp reads and longer, it is recommended to use: 21,33,55,77,99,127
+# You can also use single kmer size but it is not recommended by rnaSPAdes. (kmers: "47")
+kmers: "21,33,55"
 
 # Can be used for species name etc
 annotated_fasta_prefix: ""

--- a/config.yaml
+++ b/config.yaml
@@ -35,16 +35,23 @@ targetp: "non-pl"
 # strand_specific: "--ss rf"
 strand_specific: ""
 
-# For rnaSPAdes assembler select kmer sizes.
+# Only for rnaSPAdes assembler:
+# By default rnaSPAdes selects 2 kmer sizes, approximately 1/3 and 1/2 of read length.
+# kmers: ""
+#
+# You can also choose different kmer sizes
 # !!! all values must be odd, less than 128 and listed in ascending order !!!
 # For example:
-# kmers: "21,33,55"
+# kmers: "-k 21,33,55"
 #
-# For Illumina 150 bp reads, it is recommended to use: 21,33,55
-# For reads between 150 and 249, it is recommended to use: 21,33,55,77
-# For 250bp reads and longer, it is recommended to use: 21,33,55,77,99,127
-# You can also use single kmer size but it is not recommended by rnaSPAdes. (kmers: "47")
-kmers: "21,33,55"
+# Different sources give different recommendations for the k-mer sizes, so there is no definite recommendation.
+#
+# Recommendations by rnaSPAdes (Source: Using SPAdes De Novo Assembler https://pubmed.ncbi.nlm.nih.gov/32559359/)
+# 150 bp reads: 21,33,55 (kmers: "-k 21,33,55")
+# 150 bp - 249 bp: 21,33,55,77 (kmers: "-k 21,33,55,77")
+# 250 bp: 21,33,55,77,99,127 (kmers: "-k 21,33,55,77,99,127")
+# You can also use single kmer size but it is not recommended by rnaSPAdes. (kmers: "-k 47")
+kmers: ""
 
 # Can be used for species name etc
 annotated_fasta_prefix: ""


### PR DESCRIPTION
Added option for rnaspades to specify the strandedness.

Added option to specify kmer sizes for rnaspades, including recommendations by rnaspades team. They don't recommend using different kmer sizes than recommended and they also not recommend to use a single kmer size. https://currentprotocols.onlinelibrary.wiley.com/doi/full/10.1002/cpbi.102?saml_referrer