### PR TITLE
Rnaspades stats

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -780,7 +780,12 @@ rule trinity_stats:
     1
   shell:
     """
-    {TRINITY_HOME}/util/TrinityStats.pl {input.transcriptome} > {output.stats} 2> {log}
+    assembler={config[assembler]}
+    if [ "$assembler" -eq 'trinity' ]; then
+        {TRINITY_HOME}/util/TrinityStats.pl {input.transcriptome} > {output.stats} 2> {log}
+    else
+        {TRINITY_HOME}/util/TrinityStats.pl {input.transcriptome} | sed -e 's/trinity/rnaspades/g' > {output.stats} 2> {log}
+    fi
     {TRINITY_HOME}/util/misc/contig_ExN50_statistic.pl {input.expression} {input.transcriptome} > {output.exN50} 2>> {log}
     {TRINITY_HOME}/util/misc/plot_ExN50_statistic.Rscript {output.exN50} &>> {log}
     """

--- a/Snakefile
+++ b/Snakefile
@@ -781,7 +781,7 @@ rule trinity_stats:
   shell:
     """
     assembler={config[assembler]}
-    if [ "$assembler" -eq 'trinity' ]; then
+    if [ "$assembler" = 'trinity' ]; then
         {TRINITY_HOME}/util/TrinityStats.pl {input.transcriptome} > {output.stats} 2> {log}
     else
         {TRINITY_HOME}/util/TrinityStats.pl {input.transcriptome} | sed -e 's/trinity/rnaspades/g' > {output.stats} 2> {log}


### PR DESCRIPTION
Changes the script using this comit to speak about rnaspades in the output of trinity stats instead of trinity when rnaspades was used for the assembly. https://github.com/transXpress/transXpress/commit/24b748258e6a50f9f29ea2f36e6bdd96669f7094