### PR TITLE
fix problem with numpy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Use the provided script:
 
 Or run snakemake manually with 10 local threads:
 ~~~~
-snakemake --conda-frontend conda --use-conda --cores 10 --config samples_file=samples_file.txt
+snakemake --conda-frontend conda --use-conda --cores 10
 ~~~~
 
 Or run snakemake manually on an LSF cluster:

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - snakemake>=3.9.0
-  - python>3.6
+  - python>=3.8
   - pip
   - biopython
   - seqkit 
@@ -15,7 +15,7 @@ dependencies:
   - gcc
   - pip:
     - matplotlib>3.3.2
-    - numpy>1.19.2
+    - numpy==1.22.3
     - torch>1.7.0
     - tqdm>4.46.1
     - tmhmm.py


### PR DESCRIPTION
There was a problem with numpy version:
- we require numpy > 1.19.2
- tmhmm requires numpy < 1.24.0 because it uses feature which was removed starting from 1.24 ( it gives `AttributeError: module 'numpy' has no attribute 'int'`)

I tried to specify the version as `numpy>1.19.2,<1.24.0` but this lead to another error: `ERROR: Failed building wheel for numpy` 

I specified the numpy version =1.22.3 as suggested here https://stackoverflow.com/questions/70565965/error-failed-building-wheel-for-numpy-error-could-not-build-wheels-for-numpy#comment126799390_70566445 and it fixed the problem. This numpy version requires python >= 3.8 so i also changed the version requirement for python.