### PR TITLE
Update Snakefile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -792,7 +792,7 @@ rule transdecoder_longorfs:
     """
     rm -rf {input.transcriptome}.transdecoder_dir &> {log}
     TransDecoder.LongOrfs -t {input.transcriptome} --output_dir transdecoder &>> {log} 
-    cp -p transdecoder/longest_orfs.pep {output.orfs} &>> {log}
+    cp -p transdecoder/{input.transcriptome}.transdecoder_dir/longest_orfs.pep {output.orfs} &>> {log}
     """
 
 

--- a/Snakefile
+++ b/Snakefile
@@ -818,7 +818,7 @@ rule transdecoder_predict:
   shell:
     """
     TransDecoder.Predict -t {input.transcriptome} --output_dir transdecoder --retain_pfam_hits {input.pfam} --retain_blastp_hits {input.blastp} &> {log}
-    cp -p {input.transcriptome}.transdecoder.pep {output} &>> {log}
+    cp -p transdecoder/{input.transcriptome}.transdecoder.pep {output} &>> {log}
     """
 
 


### PR DESCRIPTION
Fixed directory in `rule transdecoder_longorfs`. The command `cp -p transdecoder/longest_orfs.pep {output.orfs} &>> {log}` creates this error :
`cp: cannot stat 'transdecoder/longest_orfs.pep': No such file or directory
`
See also attached log file.

I think inside the output directory (`./transdecoder`), it creates a subfolder `<input>.transdecoder_dir` (see attached screenshot) where results are stored, including the `longest_orfs.pep` file.

[transdecoder_longorfs.log](https://github.com/transXpress/transXpress/files/12921958/transdecoder_longorfs.log)
![Screenshot 2023-10-16 at 23 12 13](https://github.com/transXpress/transXpress/assets/65198484/ec0f327b-f24c-4b70-b622-e23b22a02074)
