### PR TITLE
Use libmamba solver for conda + dependency changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ The conda dependencies are installed in smaller conda environments automatically
 git clone https://github.com/transXpress/transXpress.git
 ~~~~
 
-2. Install [Miniconda3](https://conda.io/en/latest/miniconda.html)
+2. Install [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge)
+~~~~
+curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh"
+bash Mambaforge-Linux-x86_64.sh
+rm Mambaforge-Linux-x86_64.sh
+~~~~
 
 3. To ensure correct versions of R packages will be used unset R_LIBS_SITE
 ~~~~
@@ -53,26 +58,21 @@ unset R_LIBS_SITE
 
 4. Setup main transXpress conda environment:
 ~~~~
-conda create --name transxpress
-conda activate transxpress
-~~~~
-
-5. Install snakemake and other dependencies in the main transXpress conda environment:  
-~~~~
-conda config --add channels bioconda
-conda config --add channels conda-forge
-conda config --set channel_priority false
-conda env update --file envs/default.yaml
+mamba activate base
+mamba create -c conda-forge -c bioconda --name transxpress
+mamba activate transxpress
+conda config --set channel_priority disabled
+mamba env update --file envs/default.yaml
 ~~~~
 * (TIP: if you have a problem updating the default environment try putting python 3.9 into the *defaults.yaml* file)
 
 
 6. Create a tab-separated file called *samples.txt* in the assembly directory describing where to find your raw read FASTQ files. Create this file with the following contents:
       ~~~
-      cond_A    cond_A_rep1    A_rep1_left.fq    A_rep1_right.fq
-      cond_A    cond_A_rep2    A_rep2_left.fq    A_rep2_right.fq
-      cond_B    cond_B_rep1    B_rep1_left.fq    B_rep1_right.fq
-      cond_B    cond_B_rep2    B_rep2_left.fq    B_rep2_right.fq
+      cond_A      cond_A_rep1 A_rep1_left.fq    A_rep1_right.fq
+      cond_A      cond_A_rep2 A_rep2_left.fq    A_rep2_right.fq
+      cond_B      cond_B_rep1 B_rep1_left.fq    B_rep1_right.fq
+      cond_B      cond_B_rep2 B_rep2_left.fq    B_rep2_right.fq
       ~~~
     
 
@@ -90,7 +90,7 @@ conda env update --file envs/default.yaml
 
 8. Setup other conda environments (This will take a while):
 ~~~~
-snakemake --conda-frontend conda --use-conda --conda-create-envs-only --cores 1
+snakemake --use-conda --conda-frontend mamba --conda-create-envs-only --cores 10
 ~~~~
 
 9. Install SignalP 6.0 (fast):

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -15,8 +15,8 @@ dependencies:
   - gcc
   - pip:
     - matplotlib>3.3.2
-    - numpy==1.22.3
-    - torch>1.7.0
+    - numpy==1.23.2
+    - torch>1.7.0,<2.0
     - tqdm>4.46.1
     - tmhmm.py
     - pandas


### PR DESCRIPTION
This is just a replicated pull request from @lexi-k.

I tested the pipeline using mamba instead of conda. Everything works as expected and for now, it works better than conda since the last update of conda in July is causing some issues with the dependency solver that comes with conda. For us it mainly caused issues while solving the busco.yaml environment.

**Dependecy versions update:**
I updated the version of numpy to a higher one - 1.23.2, since numpy version 1.22.3 is only compatible with python <3.11. I also updated the version of torch to >1.7.0,<2.0, since SignalP needs a version older than 2.0. I might remove torch from the defaul.yaml file after all since SignalP should install torch itself and I believe we do not use torch in any other step of the pipeline.