### PR TITLE
Create separate environments for SignalP and TargetP

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,14 @@ snakemake --use-conda --conda-frontend mamba --conda-create-envs-only --cores 10
       * Download SignalP 6.0 fast from https://services.healthtech.dtu.dk/services/SignalP-6.0/ (go to Downloads)
       * Unpack and install signalp:
         ~~~~
+         mamba env create -f envs/signalp.yaml
+         mamba activate signalp
          tar zxvf signalp-6.0h.fast.tar.gz
          cd signalp6_fast
          pip install signalp-6-package/
          SIGNALP_DIR=$(python -c "import signalp; import os; print(os.path.dirname(signalp.__file__))" )
          cp -r signalp-6-package/models/* $SIGNALP_DIR/model_weights/
+         mamba deactivate
         ~~~~
         (make sure the conda python is used, or use the full path to python from your conda installation)
 
@@ -109,8 +112,11 @@ snakemake --use-conda --conda-frontend mamba --conda-create-envs-only --cores 10
       * Download TargetP 2.0 from https://services.healthtech.dtu.dk/software.php
       * extract the tarball and add path to targetp /bin/ folder to the PATH variable
         ~~~~
+         mamba env create -f envs/targetp.yaml
+         mamba activate targetp
          tar zxvf targetp-2.0.Linux.tar.gz
          export PATH=$PATH:`pwd`/targetp-2.0/bin
+         mamba deactivate
         ~~~~
 
 ## Running transXpress

--- a/Snakefile
+++ b/Snakefile
@@ -1331,6 +1331,8 @@ rule signalp_parallel:
     "annotations/signalp/{index}.out"
   log:
     "logs/signalp_{index}.log"
+  conda:
+    "signalp"
   params:
     memory="8"
   threads:
@@ -1354,6 +1356,8 @@ rule targetp_parallel:
     "annotations/targetp/{index}.out"
   log:
     "logs/targetp_{index}.log"
+  conda:
+    "targetp"
   params:
     memory="2"
   threads:

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -16,3 +16,4 @@ dependencies:
   - pip:
     - matplotlib>3.3.2
     - pandas
+    - tmhmm.py

--- a/envs/signalp.yaml
+++ b/envs/signalp.yaml
@@ -1,0 +1,10 @@
+name: signalp
+channels:
+  - conda-forge
+  - bioconda
+  - r
+  - defaults
+dependencies:
+  - python>=3.8,<3.12
+  - pip
+  - biopython

--- a/envs/targetp.yaml
+++ b/envs/targetp.yaml
@@ -1,0 +1,10 @@
+name: targetp
+channels:
+  - conda-forge
+  - bioconda
+  - r
+  - defaults
+dependencies:
+  - python>=3.8
+  - pip
+  - biopython

--- a/envs/tmhmm.yaml
+++ b/envs/tmhmm.yaml
@@ -1,8 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-  - r
-  - defaults
-dependencies:
-- pip:
-  - tmhmm-py


### PR DESCRIPTION
We are adding two environments (signalp.yaml, targetp.yaml) each for a specific rule in the pipeline. The users however still need to download the dependencies in the installation steps prior to running the pipeline.

I have done this regarding @tomas-pluskal's suggestion but I personally do not think these two environments are necessary since we didn't remove anything additional from the `default.yaml` file and we are adding additional steps that need to be done by the users.