### PR TITLE
Removing unused yaml file & putting tmhmm.py back in default env

### DIFF
--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - snakemake>=3.9.0
-  - python>=3.8
+  - python>=3.8,<3.12
   - pip
   - biopython
   - seqkit 
@@ -16,3 +16,4 @@ dependencies:
   - pip:
     - matplotlib>3.3.2
     - pandas
+    - tmhmm.py

--- a/envs/tmhmm.yaml
+++ b/envs/tmhmm.yaml
@@ -1,8 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-  - r
-  - defaults
-dependencies:
-- pip:
-  - tmhmm-py


### PR DESCRIPTION
- Removed unused yaml file: Deleted the `tmhmm.yaml` file as it was not used anywhere in the pipeline, which I didn't realize until now 
- Restored tmhmm dependency in the default environment: reintroduced the tmhmm.py dependency back into the `default.yaml` environment. This dependency was removed inadequately in a previous change.
- Python version condition: Using condition <3.12 on python version because of torch version conditions for SignalP