### PR TITLE
Updating snakemake version

### DIFF
--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - snakemake>=8
-  - python>=3.8
+  - python>=3.8,<3.12
   - pip
   - biopython
   - seqkit 

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -18,3 +18,4 @@ dependencies:
     - matplotlib>3.3.2
     - pandas
     - tmhmm.py
+    - numpy==1.23.2

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -4,7 +4,7 @@ channels:
   - r
   - defaults
 dependencies:
-  - snakemake>=3.9.0
+  - snakemake>=8
   - python>=3.8
   - pip
   - biopython
@@ -14,6 +14,7 @@ dependencies:
   - blast=2.10
   - gcc
   - pip:
+    - snakemake-executor-plugin-cluster-generic
     - matplotlib>3.3.2
     - pandas
     - tmhmm.py

--- a/profiles/config.yaml
+++ b/profiles/config.yaml
@@ -1,7 +1,7 @@
 # example profile config.yaml for slurm cluster
 # partition names will be different on different clusters
 
-cluster:
+cluster-generic-submit-cmd:
   sbatch
     --partition={resources.partition}
     -n {threads}


### PR DESCRIPTION
Update snakemake to the newest version 8+. This needs a change because the` --cluster` option was deprecated. Instead we need to use `--cluster-generic-submit-cmd` for which we also need a new pip dependency. See changelog v8 https://snakemake.readthedocs.io/en/stable/getting_started/migration.html for details.

We also need to specify the numpy version (becuase of tmhmm, see #66 ) about which I forgot in the previous pull request 😬 and for building a wheel for numpy we also need to specify the version of python e.g. <3.12.

I'm currently trying to implement the use of DeepTMHMM instead of TMHMM to avoid these conditions in the default environment.