### PR TITLE
Cd hit + updating snakemake version to 8+

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1794,7 +1794,7 @@ rule annotated_fasta:
       
       ## Do the work
       print ("Annotating FASTA file", input["transcriptome"], "to", output["transcriptome_annotated"], file=log_handle)
-      with open(input["input_transcriptome"], "r") as input_fasta_handle, open(output["transcriptome_annotated"], "w") as output_fasta_handle:
+      with open(input["transcriptome"], "r") as input_fasta_handle, open(output["transcriptome_annotated"], "w") as output_fasta_handle:
         for record in Bio.SeqIO.parse(input_fasta_handle, "fasta"):
           transcript_id = record.id
           record.description = "TPM: " + expression_annotations.get(transcript_id)
@@ -1805,7 +1805,7 @@ rule annotated_fasta:
           Bio.SeqIO.write(record, output_fasta_handle, "fasta")
       
       print ("Annotating FASTA file", input["proteome"], "to", output["proteome_annotated"], file=log_handle)
-      with open(input_proteome, "r") as input_fasta_handle, open(output["proteome_annotated"], "w") as output_fasta_handle:
+      with open(input["proteome"], "r") as input_fasta_handle, open(output["proteome_annotated"], "w") as output_fasta_handle:
         for record in Bio.SeqIO.parse(input_fasta_handle, "fasta"):
           transcript_id = re.sub("\\.p[0-9]+$", "", record.id)
           record.description = "transdecoder: " + re.search("ORF type:([^,]+,score=[^,]+)", record.description).group(1)

--- a/Snakefile
+++ b/Snakefile
@@ -866,6 +866,8 @@ rule parse_cdhit:
     "logs/parse_cdhit.log"
   threads:
     1
+  params:
+    memory="8"
   run:
     cl_size = 0          
     clstr_cl_size = ""  

--- a/Snakefile
+++ b/Snakefile
@@ -1511,7 +1511,7 @@ rule kallisto:
     samples="samples_trimmed.txt",
     transcriptome="transcriptome.fasta", 
     gene_trans_map="transcriptome.gene_trans_map",
-	  clustered_transcriptome="transcriptome_clst.fasta"
+    clustered_transcriptome="transcriptome_clst.fasta"
   output:
     "transcriptome_expression_isoform.tsv",
     "transcriptome_expression_gene.tsv",

--- a/Snakefile
+++ b/Snakefile
@@ -30,7 +30,7 @@ rule all:
   """
   List of target files of the transxpress pipeline.
   """
-  input: 
+  input:
     "samples_trimmed.txt",
     "transcriptome.fasta",
     "transcriptome.pep",

--- a/Snakefile
+++ b/Snakefile
@@ -51,7 +51,7 @@ rule all:
     "FastQC_comparison_after_trim.txt",
     "edgeR_trans",
     ## NOTE you can only uncomment the following if CD-HIT option is set to true in the config.yaml file
-    "cd-hit/clusters.tsv" 
+    # "cd-hit/clusters.tsv" 
 
 rule clean:
   """
@@ -834,7 +834,7 @@ rule cd_hit:
     "transcriptome.pep"
   output:
     clustered_proteome="transcriptome_clst.pep",
-    #out_dir=directory("cd-hit"),
+    proteome_original="cd-hit/transcriptome.pep",
     clusters="transcriptome_clst.pep.clstr"
   log:
     "logs/cd_hit.log"
@@ -848,10 +848,9 @@ rule cd_hit:
     """
     if [ {config[cd-hit]} = 'true' ]; then
       cd-hit -i {input} -o {output.clustered_proteome} -c 1.00 -n 5 -g 1 -d 0 &>> {log}
-      mkdir -p cd-hit
-      mv {input} -t cd-hit
-    else
-      cp {input} {output.clustered_proteome}
+      mkdir -p cd-hit &> {log}
+      cp {input} {output.proteome_original} &> {log}
+      rm -r {input} 
     fi
     """
   
@@ -1173,7 +1172,7 @@ checkpoint fasta_split_pep:
   they can be processed (annotated) in parallel.
   """
   input:
-    "transcriptome_clst.pep"
+    "transcriptome_clst.pep" if config["cd-hit"] == "true" else "transcriptome.pep"
   output:
     directory("annotations/chunks_pep")
   log:

--- a/Snakefile
+++ b/Snakefile
@@ -961,6 +961,7 @@ rule filter_transcriptome:
         if id_short in headers_short:
           Bio.SeqIO.write(record, transcriptome_filtered, 'fasta-2line')
       shutil.move(input["transcriptome_path"], "cd-hit")
+      os.remove(input["transcriptome_path"])
     # else:
     #   shutil.copy(input["transcriptome_path"], output["transcriptome_filtered"])
 

--- a/config.yaml
+++ b/config.yaml
@@ -75,3 +75,12 @@ dispersion: "0.1"
 # lineage: "eudicots_odb10"
 # You can list all possible lineages by running "busco --list-datasets"
 lineage: "eudicots_odb10"
+
+# CD-HIT option
+# By default the pipeline doesn't cluster identical sequences
+# If you would like to cluster 100% identical sequences then set this parameter to "true"
+# If set to true the pipeline will run CD-HIT with these parameters: cd-hit -i {input} -o {output} -c 1.00 -n 5 -g 1 -d 0 &>> {log}
+cd-hit: "false" 
+
+# NOTE: if you set CD-HIT to true you can also add clusters.tsv to the list of files in rule all in Snakefile
+# by adding it the pipeline will generate a tsv file with the information about the clusters CD-HIT generated

--- a/envs/cdhit.yaml
+++ b/envs/cdhit.yaml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+  - r
+  - defaults
+dependencies:
+  - cd-hit

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -4,7 +4,7 @@ channels:
   - r
   - defaults
 dependencies:
-  - snakemake>=3.9.0
+  - snakemake>=8
   - python>=3.8,<3.12
   - pip
   - biopython
@@ -14,6 +14,7 @@ dependencies:
   - blast=2.10
   - gcc
   - pip:
+    - snakemake-executor-plugin-cluster-generic
     - matplotlib>3.3.2
     - pandas
     - tmhmm.py

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - snakemake>=3.9.0
-  - python>=3.8
+  - python>=3.8,<3.12
   - pip
   - biopython
   - seqkit 

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - snakemake>=3.9.0
-  - python>=3.8,<3.12
+  - python>=3.8
   - pip
   - biopython
   - seqkit 
@@ -17,3 +17,4 @@ dependencies:
     - matplotlib>3.3.2
     - pandas
     - tmhmm.py
+    - numpy==1.23.2

--- a/profiles/config.yaml
+++ b/profiles/config.yaml
@@ -1,7 +1,7 @@
 # example profile config.yaml for slurm cluster
 # partition names will be different on different clusters
 
-cluster:
+cluster-generic-submit-cmd:
   sbatch
     --partition={resources.partition}
     -n {threads}


### PR DESCRIPTION
This pull request contains two major changes:
- adds cd-hit option to the pipeline (see #82 )
- Updates snakemake to the newest version 8+. This needs a change because the --cluster option was deprecated. Instead we need to use --cluster-generic-submit-cmd for which we also need a new pip dependency. See changelog v8 https://snakemake.readthedocs.io/en/stable/getting_started/migration.html for details. We also need to specify the numpy version (becuase of tmhmm, see https://github.com/transXpress/transXpress/pull/66 ) about which I forgot in the previous pull request 😬 and for building a wheel for numpy we also need to specify the version of python e.g. <3.12.

I'm currently trying to implement the use of DeepTMHMM instead of TMHMM to avoid these restricitons in the default environment.